### PR TITLE
Fix extensions

### DIFF
--- a/lib/lib.deno_runtime.d.ts
+++ b/lib/lib.deno_runtime.d.ts
@@ -1,4 +1,7 @@
-// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-interface */
 
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
@@ -6,8 +9,10 @@
 declare namespace Deno {
   /** The current process id of the runtime. */
   export let pid: number;
+
   /** Reflects the NO_COLOR environment variable: https://no-color.org/ */
   export let noColor: boolean;
+
   /** Check if running in terminal.
    *
    *       console.log(Deno.isTTY().stdout);
@@ -17,8 +22,16 @@ declare namespace Deno {
     stdout: boolean;
     stderr: boolean;
   };
+
+  /** Get the hostname. Requires the `--allow-env` flag.
+   *
+   *       console.log(Deno.hostname());
+   */
+  export function hostname(): string;
+
   /** Exit the Deno process with optional exit code. */
-  export function exit(exitCode?: number): never;
+  export function exit(code?: number): never;
+
   /** Returns a snapshot of the environment variables at invocation. Mutating a
    * property in the object will set that variable in the environment for
    * the process. The environment object will only accept `string`s
@@ -33,17 +46,158 @@ declare namespace Deno {
   export function env(): {
     [index: string]: string;
   };
-  /**
-   * Returns the current user's home directory.
-   * Requires the `--allow-env` flag.
+
+  /** Returns the value of an environment variable at invocation.
+   * If the variable is not present, `undefined` will be returned.
+   *
+   *       const myEnv = Deno.env();
+   *       console.log(myEnv.SHELL);
+   *       myEnv.TEST_VAR = "HELLO";
+   *       const newEnv = Deno.env();
+   *       console.log(myEnv.TEST_VAR == newEnv.TEST_VAR);
    */
-  export function homeDir(): string;
+  export function env(key: string): string | undefined;
+
+  /** UNSTABLE */
+  export type DirKind =
+    | "home"
+    | "cache"
+    | "config"
+    | "executable"
+    | "data"
+    | "data_local"
+    | "audio"
+    | "desktop"
+    | "document"
+    | "download"
+    | "font"
+    | "picture"
+    | "public"
+    | "template"
+    | "video";
+
+  // TODO(ry) markdown in jsdoc broken https://deno.land/typedoc/index.html#dir
+  /**
+   * UNSTABLE: Might rename method dir and type alias DirKind.
+   *
+   * Returns the user and platform specific directories.
+   * Requires the `--allow-env` flag.
+   * Returns null if there is no applicable directory or if any other error
+   * occurs.
+   *
+   * Argument values: "home", "cache", "config", "executable", "data",
+   * "data_local", "audio", "desktop", "document", "download", "font", "picture",
+   * "public", "template", "video"
+   *
+   * "cache"
+   * |Platform | Value                               | Example                      |
+   * | ------- | ----------------------------------- | ---------------------------- |
+   * | Linux   | `$XDG_CACHE_HOME` or `$HOME`/.cache | /home/alice/.cache           |
+   * | macOS   | `$HOME`/Library/Caches              | /Users/Alice/Library/Caches  |
+   * | Windows | `{FOLDERID_LocalAppData}`           | C:\Users\Alice\AppData\Local |
+   *
+   * "config"
+   * |Platform | Value                                 | Example                          |
+   * | ------- | ------------------------------------- | -------------------------------- |
+   * | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config              |
+   * | macOS   | `$HOME`/Library/Preferences           | /Users/Alice/Library/Preferences |
+   * | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming   |
+   *
+   * "executable"
+   * |Platform | Value                                                           | Example                |
+   * | ------- | --------------------------------------------------------------- | -----------------------|
+   * | Linux   | `XDG_BIN_HOME` or `$XDG_DATA_HOME`/../bin or `$HOME`/.local/bin | /home/alice/.local/bin |
+   * | macOS   | -                                                               | -                      |
+   * | Windows | -                                                               | -                      |
+   *
+   * "data"
+   * |Platform | Value                                    | Example                                  |
+   * | ------- | ---------------------------------------- | ---------------------------------------- |
+   * | Linux   | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/alice/.local/share                 |
+   * | macOS   | `$HOME`/Library/Application Support      | /Users/Alice/Library/Application Support |
+   * | Windows | `{FOLDERID_RoamingAppData}`              | C:\Users\Alice\AppData\Roaming           |
+   *
+   * "data_local"
+   * |Platform | Value                                    | Example                                  |
+   * | ------- | ---------------------------------------- | ---------------------------------------- |
+   * | Linux   | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/alice/.local/share                 |
+   * | macOS   | `$HOME`/Library/Application Support      | /Users/Alice/Library/Application Support |
+   * | Windows | `{FOLDERID_LocalAppData}`                | C:\Users\Alice\AppData\Local             |
+   *
+   * "audio"
+   * |Platform | Value              | Example              |
+   * | ------- | ------------------ | -------------------- |
+   * | Linux   | `XDG_MUSIC_DIR`    | /home/alice/Music    |
+   * | macOS   | `$HOME`/Music      | /Users/Alice/Music   |
+   * | Windows | `{FOLDERID_Music}` | C:\Users\Alice\Music |
+   *
+   * "desktop"
+   * |Platform | Value                | Example                |
+   * | ------- | -------------------- | ---------------------- |
+   * | Linux   | `XDG_DESKTOP_DIR`    | /home/alice/Desktop    |
+   * | macOS   | `$HOME`/Desktop      | /Users/Alice/Desktop   |
+   * | Windows | `{FOLDERID_Desktop}` | C:\Users\Alice\Desktop |
+   *
+   * "document"
+   * |Platform | Value                  | Example                  |
+   * | ------- | ---------------------- | ------------------------ |
+   * | Linux   | `XDG_DOCUMENTS_DIR`    | /home/alice/Documents    |
+   * | macOS   | `$HOME`/Documents      | /Users/Alice/Documents   |
+   * | Windows | `{FOLDERID_Documents}` | C:\Users\Alice\Documents |
+   *
+   * "download"
+   * |Platform | Value                  | Example                  |
+   * | ------- | ---------------------- | ------------------------ |
+   * | Linux   | `XDG_DOWNLOAD_DIR`     | /home/alice/Downloads    |
+   * | macOS   | `$HOME`/Downloads      | /Users/Alice/Downloads   |
+   * | Windows | `{FOLDERID_Downloads}` | C:\Users\Alice\Downloads |
+   *
+   * "font"
+   * |Platform | Value                                                | Example                        |
+   * | ------- | ---------------------------------------------------- | ------------------------------ |
+   * | Linux   | `$XDG_DATA_HOME`/fonts or `$HOME`/.local/share/fonts | /home/alice/.local/share/fonts |
+   * | macOS   | `$HOME/Library/Fonts`                                | /Users/Alice/Library/Fonts     |
+   * | Windows | –                                                    | –                              |
+   *
+   * "picture"
+   * |Platform | Value                 | Example                 |
+   * | ------- | --------------------- | ----------------------- |
+   * | Linux   | `XDG_PICTURES_DIR`    | /home/alice/Pictures    |
+   * | macOS   | `$HOME`/Pictures      | /Users/Alice/Pictures   |
+   * | Windows | `{FOLDERID_Pictures}` | C:\Users\Alice\Pictures |
+   *
+   * "public"
+   * |Platform | Value                 | Example             |
+   * | ------- | --------------------- | ------------------- |
+   * | Linux   | `XDG_PUBLICSHARE_DIR` | /home/alice/Public  |
+   * | macOS   | `$HOME`/Public        | /Users/Alice/Public |
+   * | Windows | `{FOLDERID_Public}`   | C:\Users\Public     |
+   *
+   * "template"
+   * |Platform | Value                  | Example                                                    |
+   * | ------- | ---------------------- | ---------------------------------------------------------- |
+   * | Linux   | `XDG_TEMPLATES_DIR`    | /home/alice/Templates                                      |
+   * | macOS   | –                      | –                                                          |
+   * | Windows | `{FOLDERID_Templates}` | C:\Users\Alice\AppData\Roaming\Microsoft\Windows\Templates |
+   *
+   * "video"
+   * |Platform | Value               | Example               |
+   * | ------- | ------------------- | --------------------- |
+   * | Linux   | `XDG_VIDEOS_DIR`    | /home/alice/Videos    |
+   * | macOS   | `$HOME`/Movies      | /Users/Alice/Movies   |
+   * | Windows | `{FOLDERID_Videos}` | C:\Users\Alice\Videos |
+   */
+  export function dir(kind: DirKind): string | null;
+
   /**
    * Returns the path to the current deno executable.
    * Requires the `--allow-env` flag.
    */
   export function execPath(): string;
+
   /**
+   * UNSTABLE: maybe needs permissions.
+   *
    * `cwd()` Return a string representing the current working directory.
    * If the current directory can be reached via multiple paths
    * (due to symbolic links), `cwd()` may return
@@ -51,18 +205,29 @@ declare namespace Deno {
    * throws `NotFound` exception if directory not available
    */
   export function cwd(): string;
+
   /**
+   * UNSTABLE: maybe needs permissions.
+   *
    * `chdir()` Change the current working directory to path.
    * throws `NotFound` exception if directory not available
    */
   export function chdir(directory: string): void;
-  export const EOF: null;
-  export type EOF = null;
+
+  /** UNSTABLE: might move to Deno.symbols */
+  export const EOF: unique symbol;
+
+  /** UNSTABLE: might move to Deno.symbols */
+  export type EOF = typeof EOF;
+
+  /** UNSTABLE: maybe remove "SEEK_" prefix. Maybe capitalization wrong. */
   export enum SeekMode {
     SEEK_START = 0,
     SEEK_CURRENT = 1,
     SEEK_END = 2
   }
+
+  /** UNSTABLE: Make Reader into iterator of some sort */
   export interface Reader {
     /** Reads up to p.byteLength bytes into `p`. It resolves to the number
      * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error encountered.
@@ -86,6 +251,7 @@ declare namespace Deno {
   export interface SyncReader {
     readSync(p: Uint8Array): number | EOF;
   }
+
   export interface Writer {
     /** Writes `p.byteLength` bytes from `p` to the underlying data
      * stream. It resolves to the number of bytes written from `p` (`0` <= `n` <=
@@ -140,19 +306,43 @@ declare namespace Deno {
    *      }
    */
   export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array>;
+
+  // @url js/files.d.ts
+
   /** Open a file and return an instance of the `File` object
    *  synchronously.
    *
    *       const file = Deno.openSync("/foo/bar.txt");
+   *
+   * Requires allow-read or allow-write or both depending on mode.
    */
   export function openSync(filename: string, mode?: OpenMode): File;
+
   /** Open a file and return an instance of the `File` object.
    *
-   *       (async () => {
-   *         const file = await Deno.open("/foo/bar.txt");
-   *       })();
+   *       const file = await Deno.open("/foo/bar.txt");
+   *
+   * Requires allow-read or allow-write or both depending on mode.
    */
   export function open(filename: string, mode?: OpenMode): Promise<File>;
+
+  /** Creates a file if none exists or truncates an existing file and returns
+   *  an instance of the `File` object synchronously.
+   *
+   *       const file = Deno.createSync("/foo/bar.txt");
+   *
+   * Requires allow-read and allow-write.
+   */
+  export function createSync(filename: string): File;
+  /** Creates a file if none exists or truncates an existing file and returns
+   *  an instance of the `File` object.
+   *
+   *       const file = await Deno.create("/foo/bar.txt");
+   *
+   * Requires allow-read and allow-write.
+   */
+  export function create(filename: string): Promise<File>;
+
   /** Read synchronously from a file ID into an array buffer.
    *
    * Return `number | EOF` for the operation.
@@ -164,19 +354,19 @@ declare namespace Deno {
    *
    */
   export function readSync(rid: number, p: Uint8Array): number | EOF;
-  /** Read from a file ID into an array buffer.
+
+  /** Read from a resource ID into an array buffer.
    *
    * Resolves with the `number | EOF` for the operation.
    *
-   *       (async () => {
-   *         const file = await Deno.open("/foo/bar.txt");
-   *         const buf = new Uint8Array(100);
-   *         const nread = await Deno.read(file.rid, buf);
-   *         const text = new TextDecoder().decode(buf);
-   *       })();
+   *       const file = await Deno.open("/foo/bar.txt");
+   *       const buf = new Uint8Array(100);
+   *       const nread = await Deno.read(file.rid, buf);
+   *       const text = new TextDecoder().decode(buf);
    */
   export function read(rid: number, p: Uint8Array): Promise<number | EOF>;
-  /** Write synchronously to the file ID the contents of the array buffer.
+
+  /** Write synchronously to the resource ID the contents of the array buffer.
    *
    * Resolves with the number of bytes written.
    *
@@ -186,25 +376,26 @@ declare namespace Deno {
    *       Deno.writeSync(file.rid, data);
    */
   export function writeSync(rid: number, p: Uint8Array): number;
-  /** Write to the file ID the contents of the array buffer.
+
+  /** Write to the resource ID the contents of the array buffer.
    *
    * Resolves with the number of bytes written.
    *
-   *      (async () => {
-   *        const encoder = new TextEncoder();
-   *        const data = encoder.encode("Hello world\n");
-   *        const file = await Deno.open("/foo/bar.txt");
-   *        await Deno.write(file.rid, data);
-   *      })();
+   *      const encoder = new TextEncoder();
+   *      const data = encoder.encode("Hello world\n");
+   *      const file = await Deno.open("/foo/bar.txt");
+   *      await Deno.write(file.rid, data);
    *
    */
   export function write(rid: number, p: Uint8Array): Promise<number>;
+
   /** Seek a file ID synchronously to the given offset under mode given by `whence`.
    *
    *       const file = Deno.openSync("/foo/bar.txt");
    *       Deno.seekSync(file.rid, 0, 0);
    */
   export function seekSync(rid: number, offset: number, whence: SeekMode): void;
+
   /** Seek a file ID to the given offset under mode given by `whence`.
    *
    *      (async () => {
@@ -217,8 +408,10 @@ declare namespace Deno {
     offset: number,
     whence: SeekMode
   ): Promise<void>;
-  /** Close the file ID. */
+
+  /** Close the given resource ID. */
   export function close(rid: number): void;
+
   /** The Deno abstraction for reading and writing files. */
   export class File
     implements
@@ -245,6 +438,8 @@ declare namespace Deno {
   export const stdout: File;
   /** An instance of `File` for stderr. */
   export const stderr: File;
+
+  /** UNSTABLE: merge https://github.com/denoland/deno/pull/3119 */
   export type OpenMode =
     | "r"
     /** Read-write. Start at beginning of file. */
@@ -269,6 +464,9 @@ declare namespace Deno {
     | "x"
     /** Read-write. Behaves like `x` and allows to read from file. */
     | "x+";
+
+  // @url js/buffer.d.ts
+
   /** A Buffer is a variable-sized buffer of bytes with read() and write()
    * methods. Based on https://golang.org/pkg/bytes/#Buffer
    */
@@ -346,18 +544,24 @@ declare namespace Deno {
      */
     readFromSync(r: SyncReader): number;
   }
-  /** Read `r` until EOF and return the content as `Uint8Array`.
-   */
+
+  /** Read `r` until EOF and return the content as `Uint8Array` */
   export function readAll(r: Reader): Promise<Uint8Array>;
-  /** Read synchronously `r` until EOF and return the content as `Uint8Array`.
-   */
+
+  /** Read synchronously `r` until EOF and return the content as `Uint8Array`  */
   export function readAllSync(r: SyncReader): Uint8Array;
-  /** Write all the content of `arr` to `w`.
-   */
+
+  /** Write all the content of `arr` to `w` */
   export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;
-  /** Write synchronously all the content of `arr` to `w`.
-   */
+
+  /** Write synchronously all the content of `arr` to `w` */
   export function writeAllSync(w: SyncWriter, arr: Uint8Array): void;
+
+  export interface MkdirOption {
+    recursive?: boolean;
+    mode?: number;
+  }
+
   /** Creates a new directory with the specified path synchronously.
    * If `recursive` is set to true, nested directories will be created (also known
    * as "mkdir -p").
@@ -365,13 +569,19 @@ declare namespace Deno {
    * Windows.
    *
    *       Deno.mkdirSync("new_dir");
-   *       Deno.mkdirSync("nested/directories", true);
+   *       Deno.mkdirSync("nested/directories", { recursive: true });
+   *
+   * Requires allow-write.
    */
+  export function mkdirSync(path: string, options?: MkdirOption): void;
+
+  /** Deprecated */
   export function mkdirSync(
     path: string,
     recursive?: boolean,
     mode?: number
   ): void;
+
   /** Creates a new directory with the specified path.
    * If `recursive` is set to true, nested directories will be created (also known
    * as "mkdir -p").
@@ -379,24 +589,37 @@ declare namespace Deno {
    * Windows.
    *
    *       await Deno.mkdir("new_dir");
-   *       await Deno.mkdir("nested/directories", true);
+   *       await Deno.mkdir("nested/directories", { recursive: true });
+   *
+   * Requires allow-write.
    */
+  export function mkdir(path: string, options?: MkdirOption): Promise<void>;
+
+  /** Deprecated */
   export function mkdir(
     path: string,
     recursive?: boolean,
     mode?: number
   ): Promise<void>;
+
+  // @url js/make_temp_dir.d.ts
+
   export interface MakeTempDirOptions {
     dir?: string;
     prefix?: string;
     suffix?: string;
   }
+
   /** makeTempDirSync is the synchronous version of `makeTempDir`.
    *
    *       const tempDirName0 = Deno.makeTempDirSync();
    *       const tempDirName1 = Deno.makeTempDirSync({ prefix: 'my_temp' });
+   *
+   * Requires allow-write.
    */
+  // TODO(ry) Doesn't check permissions.
   export function makeTempDirSync(options?: MakeTempDirOptions): string;
+
   /** makeTempDir creates a new temporary directory in the directory `dir`, its
    * name beginning with `prefix` and ending with `suffix`.
    * It returns the full path to the newly created directory.
@@ -407,65 +630,98 @@ declare namespace Deno {
    *
    *       const tempDirName0 = await Deno.makeTempDir();
    *       const tempDirName1 = await Deno.makeTempDir({ prefix: 'my_temp' });
+   *
+   * Requires allow-write.
    */
+  // TODO(ry) Doesn't check permissions.
   export function makeTempDir(options?: MakeTempDirOptions): Promise<string>;
+
   /** Changes the permission of a specific file/directory of specified path
    * synchronously.
    *
    *       Deno.chmodSync("/path/to/file", 0o666);
+   *
+   * Needs allow-write
    */
   export function chmodSync(path: string, mode: number): void;
+
   /** Changes the permission of a specific file/directory of specified path.
    *
    *       await Deno.chmod("/path/to/file", 0o666);
+   *
+   * Needs allow-write
    */
   export function chmod(path: string, mode: number): Promise<void>;
+
   /**
    * Change owner of a regular file or directory synchronously. Unix only at the moment.
+   *
+   * Needs allow-write permission.
+   *
    * @param path path to the file
    * @param uid user id of the new owner
    * @param gid group id of the new owner
    */
   export function chownSync(path: string, uid: number, gid: number): void;
+
   /**
    * Change owner of a regular file or directory asynchronously. Unix only at the moment.
+   *
+   * Needs allow-write permission.
+   *
    * @param path path to the file
    * @param uid user id of the new owner
    * @param gid group id of the new owner
    */
   export function chown(path: string, uid: number, gid: number): Promise<void>;
-  /** Synchronously changes the access and modification times of a file system
+
+  /** UNSTABLE: needs investigation into high precision time.
+   *
+   * Synchronously changes the access and modification times of a file system
    * object referenced by `filename`. Given times are either in seconds
    * (Unix epoch time) or as `Date` objects.
    *
    *       Deno.utimeSync("myfile.txt", 1556495550, new Date());
+   *
+   * Requires allow-write.
    */
   export function utimeSync(
     filename: string,
     atime: number | Date,
     mtime: number | Date
   ): void;
-  /** Changes the access and modification times of a file system object
+
+  /** UNSTABLE: needs investigation into high precision time.
+   *
+   * Changes the access and modification times of a file system object
    * referenced by `filename`. Given times are either in seconds
    * (Unix epoch time) or as `Date` objects.
    *
    *       await Deno.utime("myfile.txt", 1556495550, new Date());
+   *
+   * Requires allow-write.
    */
   export function utime(
     filename: string,
     atime: number | Date,
     mtime: number | Date
   ): Promise<void>;
+
+  /** UNSTABLE: rename to RemoveOptions */
   export interface RemoveOption {
     recursive?: boolean;
   }
+
   /** Removes the named file or directory synchronously. Would throw
    * error if permission denied, not found, or directory not empty if `recursive`
    * set to false.
    * `recursive` is set to false by default.
    *
    *       Deno.removeSync("/path/to/dir/or/file", {recursive: false});
+   *
+   * Requires allow-write permission.
    */
+
   export function removeSync(path: string, options?: RemoveOption): void;
   /** Removes the named file or directory. Would throw error if
    * permission denied, not found, or directory not empty if `recursive` set
@@ -473,42 +729,63 @@ declare namespace Deno {
    * `recursive` is set to false by default.
    *
    *       await Deno.remove("/path/to/dir/or/file", {recursive: false});
+   *
+   * Requires allow-write permission.
    */
   export function remove(path: string, options?: RemoveOption): Promise<void>;
+
   /** Synchronously renames (moves) `oldpath` to `newpath`. If `newpath` already
    * exists and is not a directory, `renameSync()` replaces it. OS-specific
    * restrictions may apply when `oldpath` and `newpath` are in different
    * directories.
    *
    *       Deno.renameSync("old/path", "new/path");
+   *
+   * Requires allow-read and allow-write.
    */
   export function renameSync(oldpath: string, newpath: string): void;
+
   /** Renames (moves) `oldpath` to `newpath`. If `newpath` already exists and is
    * not a directory, `rename()` replaces it. OS-specific restrictions may apply
    * when `oldpath` and `newpath` are in different directories.
    *
    *       await Deno.rename("old/path", "new/path");
+   *
+   * Requires allow-read and allow-write.
    */
   export function rename(oldpath: string, newpath: string): Promise<void>;
+
+  // @url js/read_file.d.ts
+
   /** Read the entire contents of a file synchronously.
    *
    *       const decoder = new TextDecoder("utf-8");
    *       const data = Deno.readFileSync("hello.txt");
    *       console.log(decoder.decode(data));
+   *
+   * Requires allow-read.
    */
   export function readFileSync(filename: string): Uint8Array;
+
   /** Read the entire contents of a file.
    *
    *       const decoder = new TextDecoder("utf-8");
    *       const data = await Deno.readFile("hello.txt");
    *       console.log(decoder.decode(data));
+   *
+   * Requires allow-read.
    */
   export function readFile(filename: string): Promise<Uint8Array>;
-  /** A FileInfo describes a file and is returned by `stat`, `lstat`,
+
+  /** UNSTABLE: 'len' maybe should be 'length' or 'size'.
+   *
+   * A FileInfo describes a file and is returned by `stat`, `lstat`,
    * `statSync`, `lstatSync`.
    */
   export interface FileInfo {
-    /** The size of the file, in bytes. */
+    /** UNSTABLE: 'len' maybe should be 'length' or 'size'.
+     *
+     * The size of the file, in bytes. */
     len: number;
     /** The last modification time of the file. This corresponds to the `mtime`
      * field from `stat` on Unix and `ftLastWriteTime` on Windows. This may not
@@ -525,12 +802,30 @@ declare namespace Deno {
      * be available on all platforms.
      */
     created: number | null;
-    /** The underlying raw st_mode bits that contain the standard Unix permissions
-     * for this file/directory. TODO Match behavior with Go on windows for mode.
-     */
-    mode: number | null;
     /** The file or directory name. */
     name: string | null;
+    /** ID of the device containing the file. Unix only. */
+    dev: number | null;
+    /** Inode number. Unix only. */
+    ino: number | null;
+    /** UNSTABLE: Match behavior with Go on windows for mode.
+     *
+     * The underlying raw st_mode bits that contain the standard Unix permissions
+     * for this file/directory.
+     */
+    mode: number | null;
+    /** Number of hard links pointing to this file. Unix only. */
+    nlink: number | null;
+    /** User ID of the owner of this file. Unix only. */
+    uid: number | null;
+    /** User ID of the owner of this file. Unix only. */
+    gid: number | null;
+    /** Device ID of this file. Unix only. */
+    rdev: number | null;
+    /** Blocksize for filesystem I/O. Unix only. */
+    blksize: number | null;
+    /** Number of blocks allocated to the file, in 512-byte units. Unix only. */
+    blocks: number | null;
     /** Returns whether this is info for a regular file. This result is mutually
      * exclusive to `FileInfo.isDirectory` and `FileInfo.isSymlink`.
      */
@@ -544,17 +839,47 @@ declare namespace Deno {
      */
     isSymlink(): boolean;
   }
-  /** Reads the directory given by path and returns a list of file info
+
+  // @url js/realpath.d.ts
+
+  /** Returns absolute normalized path with symbolic links resolved
+   * synchronously.
+   *
+   *       const realPath = Deno.realpathSync("./some/path");
+   *
+   * Requires allow-read.
+   */
+  export function realpathSync(path: string): string;
+
+  /** Returns absolute normalized path with symbolic links resolved.
+   *
+   *       const realPath = await Deno.realpath("./some/path");
+   *
+   * Requires allow-read.
+   */
+  export function realpath(path: string): Promise<string>;
+
+  /** UNSTABLE: Unstable rename to readdirSync.
+   *
+   * Reads the directory given by path and returns a list of file info
    * synchronously.
    *
    *       const files = Deno.readDirSync("/");
+   *
+   * Requires allow-read.
    */
   export function readDirSync(path: string): FileInfo[];
-  /** Reads the directory given by path and returns a list of file info.
+
+  /** UNSTABLE: Unstable rename to readdir. Maybe need to return AsyncIterable.
+   *
+   * Reads the directory given by path and returns a list of file info.
    *
    *       const files = await Deno.readDir("/");
+   *
+   * Requires allow-read.
    */
   export function readDir(path: string): Promise<FileInfo[]>;
+
   /** Copies the contents of a file to another by name synchronously.
    * Creates a new file if target does not exists, and if target exists,
    * overwrites original content of the target file.
@@ -563,6 +888,8 @@ declare namespace Deno {
    * to the destination.
    *
    *       Deno.copyFileSync("from.txt", "to.txt");
+   *
+   * Needs allow-read and allow-write permissions.
    */
   export function copyFileSync(from: string, to: string): void;
   /** Copies the contents of a file to another by name.
@@ -574,38 +901,75 @@ declare namespace Deno {
    * to the destination.
    *
    *       await Deno.copyFile("from.txt", "to.txt");
+   *
+   * Needs allow-read and allow-write permissions.
    */
   export function copyFile(from: string, to: string): Promise<void>;
+
+  // @url js/read_link.d.ts
+
   /** Returns the destination of the named symbolic link synchronously.
    *
    *       const targetPath = Deno.readlinkSync("symlink/path");
+   *
+   * Requires allow-read.
    */
   export function readlinkSync(name: string): string;
+
   /** Returns the destination of the named symbolic link.
    *
    *       const targetPath = await Deno.readlink("symlink/path");
+   *
+   * Requires allow-read.
    */
   export function readlink(name: string): Promise<string>;
+
+  interface StatResponse {
+    isFile: boolean;
+    isSymlink: boolean;
+    len: number;
+    modified: number;
+    accessed: number;
+    created: number;
+    name: string | null;
+    dev: number;
+    ino: number;
+    mode: number;
+    nlink: number;
+    uid: number;
+    gid: number;
+    rdev: number;
+    blksize: number;
+    blocks: number;
+  }
   /** Queries the file system for information on the path provided. If the given
    * path is a symlink information about the symlink will be returned.
    *
    *       const fileInfo = await Deno.lstat("hello.txt");
    *       assert(fileInfo.isFile());
+   *
+   * Requires allow-read permission.
    */
   export function lstat(filename: string): Promise<FileInfo>;
+
   /** Queries the file system for information on the path provided synchronously.
    * If the given path is a symlink information about the symlink will be
    * returned.
    *
    *       const fileInfo = Deno.lstatSync("hello.txt");
    *       assert(fileInfo.isFile());
+   *
+   * Requires allow-read permission.
    */
   export function lstatSync(filename: string): FileInfo;
+
   /** Queries the file system for information on the path provided. `stat` Will
    * always follow symlinks.
    *
    *       const fileInfo = await Deno.stat("hello.txt");
    *       assert(fileInfo.isFile());
+   *
+   * Requires allow-read permission.
    */
   export function stat(filename: string): Promise<FileInfo>;
   /** Queries the file system for information on the path provided synchronously.
@@ -613,40 +977,59 @@ declare namespace Deno {
    *
    *       const fileInfo = Deno.statSync("hello.txt");
    *       assert(fileInfo.isFile());
+   *
+   * Requires allow-read permission.
    */
   export function statSync(filename: string): FileInfo;
+
   /** Synchronously creates `newname` as a hard link to `oldname`.
    *
    *       Deno.linkSync("old/name", "new/name");
+   *
+   * Requires allow-read and allow-write permissions.
    */
   export function linkSync(oldname: string, newname: string): void;
+
   /** Creates `newname` as a hard link to `oldname`.
    *
    *       await Deno.link("old/name", "new/name");
+   *
+   * Requires allow-read and allow-write permissions.
    */
   export function link(oldname: string, newname: string): Promise<void>;
-  /** Synchronously creates `newname` as a symbolic link to `oldname`. The type
+
+  /** UNSTABLE type argument may be changed to "dir" | "file"
+   *
+   * Synchronously creates `newname` as a symbolic link to `oldname`. The type
    * argument can be set to `dir` or `file` and is only available on Windows
    * (ignored on other platforms).
    *
    *       Deno.symlinkSync("old/name", "new/name");
+   *
+   * Requires allow-read and allow-write permissions.
    */
   export function symlinkSync(
     oldname: string,
     newname: string,
     type?: string
   ): void;
-  /** Creates `newname` as a symbolic link to `oldname`. The type argument can be
+
+  /** UNSTABLE type argument may be changed to "dir" | "file"
+   *
+   * Creates `newname` as a symbolic link to `oldname`. The type argument can be
    * set to `dir` or `file` and is only available on Windows (ignored on other
    * platforms).
    *
    *       await Deno.symlink("old/name", "new/name");
+   *
+   * Requires allow-read and allow-write permissions.
    */
   export function symlink(
     oldname: string,
     newname: string,
     type?: string
   ): Promise<void>;
+
   /** Options for writing to a file.
    * `perm` would change the file's permission if set.
    * `create` decides if the file should be created if not exists (default: true)
@@ -657,28 +1040,36 @@ declare namespace Deno {
     create?: boolean;
     append?: boolean;
   }
+
   /** Write a new file, with given filename and data synchronously.
    *
    *       const encoder = new TextEncoder();
    *       const data = encoder.encode("Hello world\n");
    *       Deno.writeFileSync("hello.txt", data);
+   *
+   * Requires allow-write and allow-read if create is false.
    */
   export function writeFileSync(
     filename: string,
     data: Uint8Array,
     options?: WriteFileOptions
   ): void;
+
   /** Write a new file, with given filename and data.
    *
    *       const encoder = new TextEncoder();
    *       const data = encoder.encode("Hello world\n");
    *       await Deno.writeFile("hello.txt", data);
+   *
+   * Requires allow-write and allow-read if create is false.
    */
   export function writeFile(
     filename: string,
     data: Uint8Array,
     options?: WriteFileOptions
   ): Promise<void>;
+
+  /** UNSTABLE: Should not have same name as window.location type. */
   interface Location {
     /** The full url for the module, e.g. `file://some/file.ts` or
      * `https://some/file.ts`. */
@@ -688,7 +1079,10 @@ declare namespace Deno {
     /** The column number in the file.  It is assumed to be 1-indexed. */
     column: number;
   }
-  /** Given a current location in a module, lookup the source location and
+
+  /** UNSTABLE: new API, not yet vetted.
+   *
+   * Given a current location in a module, lookup the source location and
    * return it.
    *
    * When Deno transpiles code, it keep source maps of the transpiled code.  This
@@ -711,6 +1105,26 @@ declare namespace Deno {
    *
    */
   export function applySourceMap(location: Location): Location;
+
+  /** A Deno specific error.  The `kind` property is set to a specific error code
+   * which can be used to in application logic.
+   *
+   *       try {
+   *         somethingThatMightThrow();
+   *       } catch (e) {
+   *         if (
+   *           e instanceof Deno.DenoError &&
+   *           e.kind === Deno.ErrorKind.Overflow
+   *         ) {
+   *           console.error("Overflow error!");
+   *         }
+   *       }
+   *
+   */
+  export class DenoError<T extends ErrorKind> extends Error {
+    readonly kind: T;
+    constructor(kind: T, msg: string);
+  }
   export enum ErrorKind {
     NoError = 0,
     NotFound = 1,
@@ -764,56 +1178,89 @@ declare namespace Deno {
     Diagnostic = 49,
     JSError = 50
   }
-  /** A Deno specific error.  The `kind` property is set to a specific error code
-   * which can be used to in application logic.
+
+  /** UNSTABLE: potentially want names to overlap more with browser.
    *
-   *       try {
-   *         somethingThatMightThrow();
-   *       } catch (e) {
-   *         if (
-   *           e instanceof Deno.DenoError &&
-   *           e.kind === Deno.ErrorKind.Overflow
-   *         ) {
-   *           console.error("Overflow error!");
-   *         }
-   *       }
-   *
+   * Permissions as granted by the caller
+   * See: https://w3c.github.io/permissions/#permission-registry
    */
-  export class DenoError<T extends ErrorKind> extends Error {
-    readonly kind: T;
-    constructor(kind: T, msg: string);
+  export type PermissionName =
+    | "run"
+    | "read"
+    | "write"
+    | "net"
+    | "env"
+    | "plugin"
+    | "hrtime";
+  /** https://w3c.github.io/permissions/#status-of-a-permission */
+  export type PermissionState = "granted" | "denied" | "prompt";
+  interface RunPermissionDescriptor {
+    name: "run";
   }
-  /** Permissions as granted by the caller */
-  export interface Permissions {
-    read: boolean;
-    write: boolean;
-    net: boolean;
-    env: boolean;
-    run: boolean;
-    hrtime: boolean;
+  interface ReadWritePermissionDescriptor {
+    name: "read" | "write";
+    path?: string;
   }
-  export type Permission = keyof Permissions;
-  /** Inspect granted permissions for the current program.
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         // ...
-   *       }
-   */
-  export function permissions(): Permissions;
-  /** Revoke a permission. When the permission was already revoked nothing changes
-   *
-   *       if (Deno.permissions().read) {
-   *         const file = await Deno.readFile("example.test");
-   *         Deno.revokePermission('read');
-   *       }
-   *       Deno.readFile("example.test"); // -> error or permission prompt
-   */
-  export function revokePermission(permission: Permission): void;
+  interface NetPermissionDescriptor {
+    name: "net";
+    url?: string;
+  }
+  interface EnvPermissionDescriptor {
+    name: "env";
+  }
+  interface PluginPermissionDescriptor {
+    name: "plugin";
+  }
+  interface HrtimePermissionDescriptor {
+    name: "hrtime";
+  }
+  /** See: https://w3c.github.io/permissions/#permission-descriptor */
+  type PermissionDescriptor =
+    | RunPermissionDescriptor
+    | ReadWritePermissionDescriptor
+    | NetPermissionDescriptor
+    | EnvPermissionDescriptor
+    | PluginPermissionDescriptor
+    | HrtimePermissionDescriptor;
+
+  export class Permissions {
+    /** Queries the permission.
+     *       const status = await Deno.permissions.query({ name: "read", path: "/etc" });
+     *       if (status.state === "granted") {
+     *         data = await Deno.readFile("/etc/passwd");
+     *       }
+     */
+    query(d: PermissionDescriptor): Promise<PermissionStatus>;
+    /** Revokes the permission.
+     *       const status = await Deno.permissions.revoke({ name: "run" });
+     *       assert(status.state !== "granted")
+     */
+    revoke(d: PermissionDescriptor): Promise<PermissionStatus>;
+    /** Requests the permission.
+     *       const status = await Deno.permissions.request({ name: "env" });
+     *       if (status.state === "granted") {
+     *         console.log(Deno.homeDir());
+     *       } else {
+     *         console.log("'env' permission is denied.");
+     *       }
+     */
+    request(desc: PermissionDescriptor): Promise<PermissionStatus>;
+  }
+  /** UNSTABLE: maybe move to navigator.permissions to match web API. */
+  export const permissions: Permissions;
+
+  /** https://w3c.github.io/permissions/#permissionstatus */
+  export class PermissionStatus {
+    state: PermissionState;
+    constructor(state: PermissionState);
+  }
+
   /** Truncates or extends the specified file synchronously, updating the size of
    * this file to become size.
    *
    *       Deno.truncateSync("hello.txt", 10);
+   *
+   * Requires allow-write.
    */
   export function truncateSync(name: string, len?: number): void;
   /**
@@ -821,10 +1268,71 @@ declare namespace Deno {
    * become size.
    *
    *       await Deno.truncate("hello.txt", 10);
+   *
+   * Requires allow-write.
    */
   export function truncate(name: string, len?: number): Promise<void>;
-  type Network = "tcp";
-  type Addr = string;
+
+  export interface AsyncHandler {
+    (msg: Uint8Array): void;
+  }
+
+  export interface PluginOp {
+    dispatch(
+      control: Uint8Array,
+      zeroCopy?: ArrayBufferView | null
+    ): Uint8Array | null;
+    setAsyncHandler(handler: AsyncHandler): void;
+  }
+
+  export interface Plugin {
+    ops: {
+      [name: string]: PluginOp;
+    };
+  }
+
+  /** UNSTABLE: New API, not yet vetted.
+   *
+   * Open and initalize a plugin.
+   * Requires the `--allow-plugin` flag.
+   *
+   *        const plugin = Deno.openPlugin("./path/to/some/plugin.so");
+   *        const some_op = plugin.ops.some_op;
+   *        const response = some_op.dispatch(new Uint8Array([1,2,3,4]));
+   *        console.log(`Response from plugin ${response}`);
+   */
+  export function openPlugin(filename: string): Plugin;
+
+  type Transport = "tcp";
+
+  interface Addr {
+    transport: Transport;
+    /** UNSTABLE: Address is unstable because inconsistent with DialOptions. */
+    address: string;
+  }
+
+  /** UNSTABLE: Maybe remove ShutdownMode entirely. */
+  export enum ShutdownMode {
+    // See http://man7.org/linux/man-pages/man2/shutdown.2.html
+    // Corresponding to SHUT_RD, SHUT_WR, SHUT_RDWR
+    Read = 0,
+    Write,
+    ReadWrite // TODO(ry) panics on ReadWrite.
+  }
+
+  /** UNSTABLE: Maybe should remove how parameter maybe remove ShutdownMode
+   * entirely.
+   *
+   * Shutdown socket send and receive operations.
+   *
+   * Matches behavior of POSIX shutdown(3).
+   *
+   *       const listener = Deno.listen({ port: 80 });
+   *       const conn = await listener.accept();
+   *       Deno.shutdown(conn.rid, Deno.ShutdownMode.Write);
+   */
+  export function shutdown(rid: number, how: ShutdownMode): void;
+
   /** A Listener is a generic network listener for stream-oriented protocols. */
   export interface Listener extends AsyncIterator<Conn> {
     /** Waits for and resolves to the next connection to the `Listener`. */
@@ -837,10 +1345,17 @@ declare namespace Deno {
     addr(): Addr;
     [Symbol.asyncIterator](): AsyncIterator<Conn>;
   }
+
   export interface Conn extends Reader, Writer, Closer {
-    /** The local address of the connection. */
+    /** UNSTABLE: return Addr?
+     *
+     * The local address of the connection.
+     */
     localAddr: string;
-    /** The remote address of the connection. */
+    /** UNSTABLE: return Addr?
+     *
+     * The remote address of the connection.
+     */
     remoteAddr: string;
     /** The resource ID of the connection. */
     rid: number;
@@ -853,52 +1368,99 @@ declare namespace Deno {
      */
     closeWrite(): void;
   }
-  /** Listen announces on the local network address.
+
+  export interface ListenOptions {
+    port: number;
+    hostname?: string;
+    transport?: Transport;
+  }
+
+  /** Listen announces on the local transport address.
    *
-   * The network must be `tcp`, `tcp4`, `tcp6`, `unix` or `unixpacket`.
+   * Requires the allow-net permission.
    *
-   * For TCP networks, if the host in the address parameter is empty or a literal
-   * unspecified IP address, `listen()` listens on all available unicast and
-   * anycast IP addresses of the local system. To only use IPv4, use network
-   * `tcp4`. The address can use a host name, but this is not recommended,
-   * because it will create a listener for at most one of the host's IP
-   * addresses. If the port in the address parameter is empty or `0`, as in
-   * `127.0.0.1:` or `[::1]:0`, a port number is automatically chosen. The
-   * `addr()` method of `Listener` can be used to discover the chosen port.
-   *
-   * See `dial()` for a description of the network and address parameters.
-   */
-  export function listen(network: Network, address: string): Listener;
-  /** Dial connects to the address on the named network.
-   *
-   * Supported networks are only `tcp` currently.
-   *
-   * TODO: `tcp4` (IPv4-only), `tcp6` (IPv6-only), `udp`, `udp4` (IPv4-only),
-   * `udp6` (IPv6-only), `ip`, `ip4` (IPv4-only), `ip6` (IPv6-only), `unix`,
-   * `unixgram` and `unixpacket`.
-   *
-   * For TCP and UDP networks, the address has the form `host:port`. The host must
-   * be a literal IP address, or a host name that can be resolved to IP addresses.
-   * The port must be a literal port number or a service name. If the host is a
-   * literal IPv6 address it must be enclosed in square brackets, as in
-   * `[2001:db8::1]:80` or `[fe80::1%zone]:80`. The zone specifies the scope of
-   * the literal IPv6 address as defined in RFC 4007. The functions JoinHostPort
-   * and SplitHostPort manipulate a pair of host and port in this form. When using
-   * TCP, and the host resolves to multiple IP addresses, Dial will try each IP
-   * address in order until one succeeds.
+   * @param options
+   * @param options.port The port to connect to. (Required.)
+   * @param options.hostname A literal IP address or host name that can be
+   *   resolved to an IP address. If not specified, defaults to 0.0.0.0
+   * @param options.transport Defaults to "tcp". Later we plan to add "tcp4",
+   *   "tcp6", "udp", "udp4", "udp6", "ip", "ip4", "ip6", "unix", "unixgram" and
+   *   "unixpacket".
    *
    * Examples:
    *
-   *     dial("tcp", "golang.org:http")
-   *     dial("tcp", "192.0.2.1:http")
-   *     dial("tcp", "198.51.100.1:80")
-   *     dial("udp", "[2001:db8::1]:domain")
-   *     dial("udp", "[fe80::1%lo0]:53")
-   *     dial("tcp", ":80")
+   *     listen({ port: 80 })
+   *     listen({ hostname: "192.0.2.1", port: 80 })
+   *     listen({ hostname: "[2001:db8::1]", port: 80 });
+   *     listen({ hostname: "golang.org", port: 80, transport: "tcp" })
    */
-  export function dial(network: Network, address: string): Promise<Conn>;
-  /** **RESERVED** */
-  export function connect(_network: Network, _address: string): Promise<Conn>;
+  export function listen(options: ListenOptions): Listener;
+
+  export interface ListenTLSOptions {
+    port: number;
+    hostname?: string;
+    transport?: Transport;
+    certFile: string;
+    keyFile: string;
+  }
+
+  /** Listen announces on the local transport address over TLS (transport layer security).
+   *
+   * @param options
+   * @param options.port The port to connect to. (Required.)
+   * @param options.hostname A literal IP address or host name that can be
+   *   resolved to an IP address. If not specified, defaults to 0.0.0.0
+   * @param options.certFile Server certificate file
+   * @param options.keyFile Server public key file
+   *
+   * Examples:
+   *
+   *     Deno.listenTLS({ port: 443, certFile: "./my_server.crt", keyFile: "./my_server.key" })
+   */
+  export function listenTLS(options: ListenTLSOptions): Listener;
+
+  /** UNSTABLE rename to ConnectOptions */
+  export interface DialOptions {
+    port: number;
+    hostname?: string;
+    transport?: Transport;
+  }
+
+  /** UNSTABLE: Rename to connect.
+   *
+   * Dial connects to the address on the named transport.
+   *
+   * @param options
+   * @param options.port The port to connect to. (Required.)
+   * @param options.hostname A literal IP address or host name that can be
+   *   resolved to an IP address. If not specified, defaults to 127.0.0.1
+   * @param options.transport Defaults to "tcp". Later we plan to add "tcp4",
+   *   "tcp6", "udp", "udp4", "udp6", "ip", "ip4", "ip6", "unix", "unixgram" and
+   *   "unixpacket".
+   *
+   * Examples:
+   *
+   *     dial({ port: 80 })
+   *     dial({ hostname: "192.0.2.1", port: 80 })
+   *     dial({ hostname: "[2001:db8::1]", port: 80 });
+   *     dial({ hostname: "golang.org", port: 80, transport: "tcp" })
+   */
+  export function dial(options: DialOptions): Promise<Conn>;
+
+  /** UNSTABLE: rename to ConnectTLSOptions */
+  export interface DialTLSOptions {
+    port: number;
+    hostname?: string;
+    certFile?: string;
+  }
+
+  /** UNSTABLE: rename to connectTLS.
+   *
+   * dialTLS establishes a secure connection over TLS (transport layer security).
+   */
+  export function dialTLS(options: DialTLSOptions): Promise<Conn>;
+
+  /** UNSTABLE: not sure if broken or not */
   export interface Metrics {
     opsDispatched: number;
     opsCompleted: number;
@@ -906,7 +1468,10 @@ declare namespace Deno {
     bytesSentData: number;
     bytesReceived: number;
   }
-  /** Receive metrics from the privileged side of Deno.
+
+  /** UNSTABLE: potentially broken.
+   *
+   * Receive metrics from the privileged side of Deno.
    *
    *      > console.table(Deno.metrics())
    *      ┌──────────────────┬────────┐
@@ -920,13 +1485,19 @@ declare namespace Deno {
    *      └──────────────────┴────────┘
    */
   export function metrics(): Metrics;
+
+  /** UNSTABLE: reconsider representation. */
   interface ResourceMap {
     [rid: number]: string;
   }
-  /** Returns a map of open _file like_ resource ids along with their string
+
+  /** UNSTABLE: reconsider return type.
+   *
+   * Returns a map of open _file like_ resource ids along with their string
    * representation.
    */
   export function resources(): ResourceMap;
+
   /** How to handle subprocess stdio.
    *
    * "inherit" The default if unspecified. The child inherits from the
@@ -939,22 +1510,22 @@ declare namespace Deno {
    * stream to /dev/null.
    */
   type ProcessStdio = "inherit" | "piped" | "null";
-  export interface RunOptions {
-    args: string[];
-    cwd?: string;
-    env?: {
-      [key: string]: string;
-    };
-    stdout?: ProcessStdio | number;
-    stderr?: ProcessStdio | number;
-    stdin?: ProcessStdio | number;
-  }
-  /** Send a signal to process under given PID. Unix only at this moment.
+
+  /** UNSTABLE: the signo parameter maybe shouldn't be number.
+   *
+   * Send a signal to process under given PID. Unix only at this moment.
    * If pid is negative, the signal will be sent to the process group identified
    * by -pid.
+   *
    * Requires the `--allow-run` flag.
+   *
+   * Currently no-op on Windows. TODO Should throw on windows instead of silently succeeding.
    */
   export function kill(pid: number, signo: number): void;
+
+  /** UNSTABLE: There are some issues to work out with respect to when and how
+   * the process should be closed.
+   */
   export class Process {
     readonly rid: number;
     readonly pid: number;
@@ -975,11 +1546,27 @@ declare namespace Deno {
     close(): void;
     kill(signo: number): void;
   }
+
   export interface ProcessStatus {
     success: boolean;
     code?: number;
     signal?: number;
   }
+
+  /** UNSTABLE:  Maybe rename args to argv to differentiate from Deno.args Note
+   * the first element needs to be a path to the binary.
+   */
+  export interface RunOptions {
+    args: string[];
+    cwd?: string;
+    env?: {
+      [key: string]: string;
+    };
+    stdout?: ProcessStdio | number;
+    stderr?: ProcessStdio | number;
+    stdin?: ProcessStdio | number;
+  }
+
   /**
    * Spawns new subprocess.
    *
@@ -994,6 +1581,7 @@ declare namespace Deno {
    * they can be set to either `ProcessStdio` or `rid` of open file.
    */
   export function run(opt: RunOptions): Process;
+
   enum LinuxSignal {
     SIGHUP = 1,
     SIGINT = 2,
@@ -1060,75 +1648,32 @@ declare namespace Deno {
     SIGUSR1 = 30,
     SIGUSR2 = 31
   }
-  /** Signals numbers. This is platform dependent.
+  /** UNSTABLE: make platform independent.
+   *
+   * Signals numbers. This is platform dependent.
    */
   export const Signal: typeof MacOSSignal | typeof LinuxSignal;
-  export {};
+
+  /** UNSTABLE: rename to InspectOptions */
   type ConsoleOptions = Partial<{
     showHidden: boolean;
     depth: number;
     colors: boolean;
     indentLevel: number;
   }>;
-  class CSI {
-    static kClear: string;
-    static kClearScreenDown: string;
-  }
-  export const isConsoleInstance: unique symbol;
-  class Console {
-    private printFunc;
-    indentLevel: number;
-    [isConsoleInstance]: boolean;
-    /** Writes the arguments to stdout */
-    log: (...args: unknown[]) => void;
-    /** Writes the arguments to stdout */
-    debug: (...args: unknown[]) => void;
-    /** Writes the arguments to stdout */
-    info: (...args: unknown[]) => void;
-    /** Writes the properties of the supplied `obj` to stdout */
-    dir: (
-      obj: unknown,
-      options?: Partial<{
-        showHidden: boolean;
-        depth: number;
-        colors: boolean;
-        indentLevel: number;
-      }>
-    ) => void;
-    /** Writes the arguments to stdout */
-    warn: (...args: unknown[]) => void;
-    /** Writes the arguments to stdout */
-    error: (...args: unknown[]) => void;
-    /** Writes an error message to stdout if the assertion is `false`. If the
-     * assertion is `true`, nothing happens.
-     *
-     * ref: https://console.spec.whatwg.org/#assert
-     */
-    assert: (condition?: boolean, ...args: unknown[]) => void;
-    count: (label?: string) => void;
-    countReset: (label?: string) => void;
-    table: (data: unknown, properties?: string[] | undefined) => void;
-    time: (label?: string) => void;
-    timeLog: (label?: string, ...args: unknown[]) => void;
-    timeEnd: (label?: string) => void;
-    group: (...label: unknown[]) => void;
-    groupCollapsed: (...label: unknown[]) => void;
-    groupEnd: () => void;
-    clear: () => void;
-    trace: (...args: unknown[]) => void;
-    static [Symbol.hasInstance](instance: Console): boolean;
-  }
-  /** A symbol which can be used as a key for a custom method which will be called
-   * when `Deno.inspect()` is called, or when the object is logged to the console.
-   */
-  export const customInspect: unique symbol;
-  /**
+
+  /** UNSTABLE: ConsoleOptions rename to InspectOptions. Also the exact form of
+   * string output subject to change.
+   *
    * `inspect()` converts input into string that has the same format
    * as printed by `console.log(...)`;
    */
   export function inspect(value: unknown, options?: ConsoleOptions): string;
+
   export type OperatingSystem = "mac" | "win" | "linux";
+
   export type Arch = "x64" | "arm64";
+
   /** Build related information */
   interface BuildInfo {
     /** The CPU architecture. */
@@ -1136,130 +1681,567 @@ declare namespace Deno {
     /** The operating system. */
     os: OperatingSystem;
   }
+
   export const build: BuildInfo;
-  export const platform: BuildInfo;
+
   interface Version {
     deno: string;
     v8: string;
     typescript: string;
   }
   export const version: Version;
-  export {};
+
+  /** The log category for a diagnostic message */
+  export enum DiagnosticCategory {
+    Log = 0,
+    Debug = 1,
+    Info = 2,
+    Error = 3,
+    Warning = 4,
+    Suggestion = 5
+  }
+
+  export interface DiagnosticMessageChain {
+    message: string;
+    category: DiagnosticCategory;
+    code: number;
+    next?: DiagnosticMessageChain[];
+  }
+
+  export interface DiagnosticItem {
+    /** A string message summarizing the diagnostic. */
+    message: string;
+
+    /** An ordered array of further diagnostics. */
+    messageChain?: DiagnosticMessageChain;
+
+    /** Information related to the diagnostic.  This is present when there is a
+     * suggestion or other additional diagnostic information */
+    relatedInformation?: DiagnosticItem[];
+
+    /** The text of the source line related to the diagnostic */
+    sourceLine?: string;
+
+    /** The line number that is related to the diagnostic */
+    lineNumber?: number;
+
+    /** The name of the script resource related to the diagnostic */
+    scriptResourceName?: string;
+
+    /** The start position related to the diagnostic */
+    startPosition?: number;
+
+    /** The end position related to the diagnostic */
+    endPosition?: number;
+
+    /** The category of the diagnostic */
+    category: DiagnosticCategory;
+
+    /** A number identifier */
+    code: number;
+
+    /** The the start column of the sourceLine related to the diagnostic */
+    startColumn?: number;
+
+    /** The end column of the sourceLine related to the diagnostic */
+    endColumn?: number;
+  }
+
+  export interface Diagnostic {
+    /** An array of diagnostic items. */
+    items: DiagnosticItem[];
+  }
+
+  /** UNSTABLE: new API, yet to be vetted.
+   *
+   * A specific subset TypeScript compiler options that can be supported by
+   * the Deno TypeScript compiler.
+   */
+  export interface CompilerOptions {
+    /** Allow JavaScript files to be compiled. Defaults to `true`. */
+    allowJs?: boolean;
+
+    /** Allow default imports from modules with no default export. This does not
+     * affect code emit, just typechecking. Defaults to `false`. */
+    allowSyntheticDefaultImports?: boolean;
+
+    /** Allow accessing UMD globals from modules. Defaults to `false`. */
+    allowUmdGlobalAccess?: boolean;
+
+    /** Do not report errors on unreachable code. Defaults to `false`. */
+    allowUnreachableCode?: boolean;
+
+    /** Do not report errors on unused labels. Defaults to `false` */
+    allowUnusedLabels?: boolean;
+
+    /** Parse in strict mode and emit `"use strict"` for each source file.
+     * Defaults to `true`. */
+    alwaysStrict?: boolean;
+
+    /** Base directory to resolve non-relative module names. Defaults to
+     * `undefined`. */
+    baseUrl?: string;
+
+    /** Report errors in `.js` files. Use in conjunction with `allowJs`. Defaults
+     * to `false`. */
+    checkJs?: boolean;
+
+    /** Generates corresponding `.d.ts` file. Defaults to `false`. */
+    declaration?: boolean;
+
+    /** Output directory for generated declaration files. */
+    declarationDir?: string;
+
+    /** Generates a source map for each corresponding `.d.ts` file. Defaults to
+     * `false`. */
+    declarationMap?: boolean;
+
+    /** Provide full support for iterables in `for..of`, spread and
+     * destructuring when targeting ES5 or ES3.  Defaults to `false`. */
+    downlevelIteration?: boolean;
+
+    /** Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.
+     * Defaults to `false`. */
+    emitBOM?: boolean;
+
+    /** Only emit `.d.ts` declaration files. Defaults to `false`. */
+    emitDeclarationOnly?: boolean;
+
+    /** Emit design-type metadata for decorated declarations in source. See issue
+     * [microsoft/TypeScript#2577](https://github.com/Microsoft/TypeScript/issues/2577)
+     * for details. Defaults to `false`. */
+    emitDecoratorMetadata?: boolean;
+
+    /** Emit `__importStar` and `__importDefault` helpers for runtime babel
+     * ecosystem compatibility and enable `allowSyntheticDefaultImports` for type
+     * system compatibility. Defaults to `true`. */
+    esModuleInterop?: boolean;
+
+    /** Enables experimental support for ES decorators. Defaults to `false`. */
+    experimentalDecorators?: boolean;
+
+    /** Emit a single file with source maps instead of having a separate file.
+     * Defaults to `false`. */
+    inlineSourceMap?: boolean;
+
+    /** Emit the source alongside the source maps within a single file; requires
+     * `inlineSourceMap` or `sourceMap` to be set. Defaults to `false`. */
+    inlineSources?: boolean;
+
+    /** Perform additional checks to ensure that transpile only would be safe.
+     * Defaults to `false`. */
+    isolatedModules?: boolean;
+
+    /** Support JSX in `.tsx` files: `"react"`, `"preserve"`, `"react-native"`.
+     * Defaults to `"react"`. */
+    jsx?: "react" | "preserve" | "react-native";
+
+    /** Specify the JSX factory function to use when targeting react JSX emit,
+     * e.g. `React.createElement` or `h`. Defaults to `React.createElement`. */
+    jsxFactory?: string;
+
+    /** Resolve keyof to string valued property names only (no numbers or
+     * symbols). Defaults to `false`. */
+    keyofStringsOnly?: string;
+
+    /** Emit class fields with ECMAScript-standard semantics. Defaults to `false`.
+     * Does not apply to `"esnext"` target. */
+    useDefineForClassFields?: boolean;
+
+    /** The locale to use to show error messages. */
+    locale?: string;
+
+    /** Specifies the location where debugger should locate map files instead of
+     * generated locations. Use this flag if the `.map` files will be located at
+     * run-time in a different location than the `.js` files. The location
+     * specified will be embedded in the source map to direct the debugger where
+     * the map files will be located. Defaults to `undefined`. */
+    mapRoot?: string;
+
+    /** Specify the module format for the emitted code.  Defaults to
+     * `"esnext"`. */
+    module?:
+      | "none"
+      | "commonjs"
+      | "amd"
+      | "system"
+      | "umd"
+      | "es6"
+      | "es2015"
+      | "esnext";
+
+    /** Do not generate custom helper functions like `__extends` in compiled
+     * output. Defaults to `false`. */
+    noEmitHelpers?: boolean;
+
+    /** Report errors for fallthrough cases in switch statement. Defaults to
+     * `false`. */
+    noFallthroughCasesInSwitch?: boolean;
+
+    /** Raise error on expressions and declarations with an implied any type.
+     * Defaults to `true`. */
+    noImplicitAny?: boolean;
+
+    /** Report an error when not all code paths in function return a value.
+     * Defaults to `false`. */
+    noImplicitReturns?: boolean;
+
+    /** Raise error on `this` expressions with an implied `any` type. Defaults to
+     * `true`. */
+    noImplicitThis?: boolean;
+
+    /** Do not emit `"use strict"` directives in module output. Defaults to
+     * `false`. */
+    noImplicitUseStrict?: boolean;
+
+    /** Do not add triple-slash references or module import targets to the list of
+     * compiled files. Defaults to `false`. */
+    noResolve?: boolean;
+
+    /** Disable strict checking of generic signatures in function types. Defaults
+     * to `false`. */
+    noStrictGenericChecks?: boolean;
+
+    /** Report errors on unused locals. Defaults to `false`. */
+    noUnusedLocals?: boolean;
+
+    /** Report errors on unused parameters. Defaults to `false`. */
+    noUnusedParameters?: boolean;
+
+    /** Redirect output structure to the directory. This only impacts
+     * `Deno.compile` and only changes the emitted file names.  Defaults to
+     * `undefined`. */
+    outDir?: string;
+
+    /** List of path mapping entries for module names to locations relative to the
+     * `baseUrl`. Defaults to `undefined`. */
+    paths?: Record<string, string[]>;
+
+    /** Do not erase const enum declarations in generated code. Defaults to
+     * `false`. */
+    preserveConstEnums?: boolean;
+
+    /** Remove all comments except copy-right header comments beginning with
+     * `/*!`. Defaults to `true`. */
+    removeComments?: boolean;
+
+    /** Include modules imported with `.json` extension. Defaults to `true`. */
+    resolveJsonModule?: boolean;
+
+    /** Specifies the root directory of input files. Only use to control the
+     * output directory structure with `outDir`. Defaults to `undefined`. */
+    rootDir?: string;
+
+    /** List of _root_ folders whose combined content represent the structure of
+     * the project at runtime. Defaults to `undefined`. */
+    rootDirs?: string[];
+
+    /** Generates corresponding `.map` file. Defaults to `false`. */
+    sourceMap?: boolean;
+
+    /** Specifies the location where debugger should locate TypeScript files
+     * instead of source locations. Use this flag if the sources will be located
+     * at run-time in a different location than that at design-time. The location
+     * specified will be embedded in the sourceMap to direct the debugger where
+     * the source files will be located. Defaults to `undefined`. */
+    sourceRoot?: string;
+
+    /** Enable all strict type checking options. Enabling `strict` enables
+     * `noImplicitAny`, `noImplicitThis`, `alwaysStrict`, `strictBindCallApply`,
+     * `strictNullChecks`, `strictFunctionTypes` and
+     * `strictPropertyInitialization`. Defaults to `true`. */
+    strict?: boolean;
+
+    /** Enable stricter checking of the `bind`, `call`, and `apply` methods on
+     * functions. Defaults to `true`. */
+    strictBindCallApply?: boolean;
+
+    /** Disable bivariant parameter checking for function types. Defaults to
+     * `true`. */
+    strictFunctionTypes?: boolean;
+
+    /** Ensure non-undefined class properties are initialized in the constructor.
+     * This option requires `strictNullChecks` be enabled in order to take effect.
+     * Defaults to `true`. */
+    strictPropertyInitialization?: boolean;
+
+    /** In strict null checking mode, the `null` and `undefined` values are not in
+     * the domain of every type and are only assignable to themselves and `any`
+     * (the one exception being that `undefined` is also assignable to `void`). */
+    strictNullChecks?: boolean;
+
+    /** Suppress excess property checks for object literals. Defaults to
+     * `false`. */
+    suppressExcessPropertyErrors?: boolean;
+
+    /** Suppress `noImplicitAny` errors for indexing objects lacking index
+     * signatures. */
+    suppressImplicitAnyIndexErrors?: boolean;
+
+    /** Specify ECMAScript target version. Defaults to `esnext`. */
+    target?:
+      | "es3"
+      | "es5"
+      | "es6"
+      | "es2015"
+      | "es2016"
+      | "es2017"
+      | "es2018"
+      | "es2019"
+      | "es2020"
+      | "esnext";
+
+    /** List of names of type definitions to include. Defaults to `undefined`. */
+    types?: string[];
+  }
+
+  /** UNSTABLE: new API, yet to be vetted.
+   *
+   * The results of a transpile only command, where the `source` contains the
+   * emitted source, and `map` optionally contains the source map.
+   */
+  export interface TranspileOnlyResult {
+    source: string;
+    map?: string;
+  }
+
+  /** UNSTABLE: new API, yet to be vetted.
+   *
+   * Takes a set of TypeScript sources and resolves with a map where the key was
+   * the original file name provided in sources and the result contains the
+   * `source` and optionally the `map` from the transpile operation. This does no
+   * type checking and validation, it effectively "strips" the types from the
+   * file.
+   *
+   *      const results =  await Deno.transpileOnly({
+   *        "foo.ts": `const foo: string = "foo";`
+   *      });
+   *
+   * @param sources A map where the key is the filename and the value is the text
+   *                to transpile.  The filename is only used in the transpile and
+   *                not resolved, for example to fill in the source name in the
+   *                source map.
+   * @param options An option object of options to send to the compiler. This is
+   *                a subset of ts.CompilerOptions which can be supported by Deno.
+   *                Many of the options related to type checking and emitting
+   *                type declaration files will have no impact on the output.
+   */
+  export function transpileOnly(
+    sources: Record<string, string>,
+    options?: CompilerOptions
+  ): Promise<Record<string, TranspileOnlyResult>>;
+
+  /** UNSTABLE: new API, yet to be vetted.
+   *
+   * Takes a root module name, any optionally a record set of sources. Resolves
+   * with a compiled set of modules.  If just a root name is provided, the modules
+   * will be resolved as if the root module had been passed on the command line.
+   *
+   * If sources are passed, all modules will be resolved out of this object, where
+   * the key is the module name and the value is the content.  The extension of
+   * the module name will be used to determine the media type of the module.
+   *
+   *      const [ maybeDiagnostics1, output1 ] = await Deno.compile("foo.ts");
+   *
+   *      const [ maybeDiagnostics2, output2 ] = await Deno.compile("/foo.ts", {
+   *        "/foo.ts": `export * from "./bar.ts";`,
+   *        "/bar.ts": `export const bar = "bar";`
+   *      });
+   *
+   * @param rootName The root name of the module which will be used as the
+   *                 "starting point".  If no `sources` is specified, Deno will
+   *                 resolve the module externally as if the `rootName` had been
+   *                 specified on the command line.
+   * @param sources An optional key/value map of sources to be used when resolving
+   *                modules, where the key is the module name, and the value is
+   *                the source content.  The extension of the key will determine
+   *                the media type of the file when processing.  If supplied,
+   *                Deno will not attempt to resolve any modules externally.
+   * @param options An optional object of options to send to the compiler. This is
+   *                a subset of ts.CompilerOptions which can be supported by Deno.
+   */
+  export function compile(
+    rootName: string,
+    sources?: Record<string, string>,
+    options?: CompilerOptions
+  ): Promise<[Diagnostic | undefined, Record<string, string>]>;
+
+  /** UNSTABLE: new API, yet to be vetted.
+   *
+   * Takes a root module name, and optionally a record set of sources. Resolves
+   * with a single JavaScript string that is like the output of a `deno bundle`
+   * command.  If just a root name is provided, the modules will be resolved as if
+   * the root module had been passed on the command line.
+   *
+   * If sources are passed, all modules will be resolved out of this object, where
+   * the key is the module name and the value is the content. The extension of the
+   * module name will be used to determine the media type of the module.
+   *
+   *      const [ maybeDiagnostics1, output1 ] = await Deno.bundle("foo.ts");
+   *
+   *      const [ maybeDiagnostics2, output2 ] = await Deno.bundle("/foo.ts", {
+   *        "/foo.ts": `export * from "./bar.ts";`,
+   *        "/bar.ts": `export const bar = "bar";`
+   *      });
+   *
+   * @param rootName The root name of the module which will be used as the
+   *                 "starting point".  If no `sources` is specified, Deno will
+   *                 resolve the module externally as if the `rootName` had been
+   *                 specified on the command line.
+   * @param sources An optional key/value map of sources to be used when resolving
+   *                modules, where the key is the module name, and the value is
+   *                the source content.  The extension of the key will determine
+   *                the media type of the file when processing.  If supplied,
+   *                Deno will not attempt to resolve any modules externally.
+   * @param options An optional object of options to send to the compiler. This is
+   *                a subset of ts.CompilerOptions which can be supported by Deno.
+   */
+  export function bundle(
+    rootName: string,
+    sources?: Record<string, string>,
+    options?: CompilerOptions
+  ): Promise<[Diagnostic | undefined, string]>;
+
+  /** Returns the script arguments to the program. If for example we run a program
+   *
+   *   deno --allow-read https://deno.land/std/examples/cat.ts /etc/passwd
+   *
+   * Then Deno.args will contain just
+   *
+   *   [ "/etc/passwd" ]
+   */
   export const args: string[];
+
+  /** UNSTABLE: new API. Maybe move EOF here.
+   *
+   * Special Deno related symbols.
+   */
+  export const symbols: {
+    /** Symbol to access exposed internal Deno API */
+    readonly internal: unique symbol;
+    /** A symbol which can be used as a key for a custom method which will be called
+     * when `Deno.inspect()` is called, or when the object is logged to the console.
+     */
+    readonly customInspect: unique symbol;
+    // TODO(ry) move EOF here?
+  };
 }
 
 declare interface Window {
-  window: Window;
-  atob: typeof textEncoding.atob;
-  btoa: typeof textEncoding.btoa;
-  fetch: typeof fetchTypes.fetch;
-  clearTimeout: typeof timers.clearTimeout;
-  clearInterval: typeof timers.clearInterval;
-  console: consoleTypes.Console;
-  setTimeout: typeof timers.setTimeout;
-  setInterval: typeof timers.setInterval;
-  location: domTypes.Location;
+  window: Window & typeof globalThis;
+  atob: typeof __textEncoding.atob;
+  btoa: typeof __textEncoding.btoa;
+  fetch: typeof __fetch.fetch;
+  clearTimeout: typeof __timers.clearTimeout;
+  clearInterval: typeof __timers.clearInterval;
+  console: __console.Console;
+  setTimeout: typeof __timers.setTimeout;
+  setInterval: typeof __timers.setInterval;
+  location: __domTypes.Location;
   onload: Function | undefined;
+  onunload: Function | undefined;
   crypto: Crypto;
-  Blob: typeof blob.DenoBlob;
-  File: domTypes.DomFileConstructor;
-  CustomEventInit: typeof customEvent.CustomEventInit;
-  CustomEvent: typeof customEvent.CustomEvent;
-  EventInit: typeof event.EventInit;
-  Event: typeof event.Event;
-  EventListener: typeof eventTarget.EventListener;
-  EventTarget: typeof eventTarget.EventTarget;
-  URL: typeof url.URL;
-  URLSearchParams: typeof urlSearchParams.URLSearchParams;
-  Headers: domTypes.HeadersConstructor;
-  FormData: domTypes.FormDataConstructor;
-  TextEncoder: typeof textEncoding.TextEncoder;
-  TextDecoder: typeof textEncoding.TextDecoder;
-  Request: domTypes.RequestConstructor;
-  Response: typeof fetchTypes.Response;
-  performance: performanceUtil.Performance;
+  Blob: typeof __blob.DenoBlob;
+  File: __domTypes.DomFileConstructor;
+  CustomEvent: typeof __customEvent.CustomEvent;
+  Event: typeof __event.Event;
+  EventTarget: typeof __eventTarget.EventTarget;
+  URL: typeof __url.URL;
+  URLSearchParams: typeof __urlSearchParams.URLSearchParams;
+  Headers: __domTypes.HeadersConstructor;
+  FormData: __domTypes.FormDataConstructor;
+  TextEncoder: typeof __textEncoding.TextEncoder;
+  TextDecoder: typeof __textEncoding.TextDecoder;
+  Request: __domTypes.RequestConstructor;
+  Response: typeof __fetch.Response;
+  performance: __performanceUtil.Performance;
   onmessage: (e: { data: any }) => void;
-  workerMain: typeof workers.workerMain;
-  workerClose: typeof workers.workerClose;
-  postMessage: typeof workers.postMessage;
-  Worker: typeof workers.WorkerImpl;
+  onerror: undefined | typeof onerror;
+  workerMain: typeof __workers.workerMain;
+  workerClose: typeof __workers.workerClose;
+  postMessage: typeof __workers.postMessage;
+  Worker: typeof __workers.WorkerImpl;
   addEventListener: (
     type: string,
-    callback: (event: domTypes.Event) => void | null,
-    options?: boolean | domTypes.AddEventListenerOptions | undefined
+    callback: (event: __domTypes.Event) => void | null,
+    options?: boolean | __domTypes.AddEventListenerOptions | undefined
   ) => void;
-  dispatchEvent: (event: domTypes.Event) => boolean;
+  dispatchEvent: (event: __domTypes.Event) => boolean;
   removeEventListener: (
     type: string,
-    callback: (event: domTypes.Event) => void | null,
-    options?: boolean | domTypes.EventListenerOptions | undefined
+    callback: (event: __domTypes.Event) => void | null,
+    options?: boolean | __domTypes.EventListenerOptions | undefined
   ) => void;
+  queueMicrotask: (task: () => void) => void;
   Deno: typeof Deno;
 }
 
-declare const window: Window;
-declare const atob: typeof textEncoding.atob;
-declare const btoa: typeof textEncoding.btoa;
-declare const fetch: typeof fetchTypes.fetch;
-declare const clearTimeout: typeof timers.clearTimeout;
-declare const clearInterval: typeof timers.clearInterval;
-declare const console: consoleTypes.Console;
-declare const setTimeout: typeof timers.setTimeout;
-declare const setInterval: typeof timers.setInterval;
-declare const location: domTypes.Location;
+declare const window: Window & typeof globalThis;
+declare const atob: typeof __textEncoding.atob;
+declare const btoa: typeof __textEncoding.btoa;
+declare const fetch: typeof __fetch.fetch;
+declare const clearTimeout: typeof __timers.clearTimeout;
+declare const clearInterval: typeof __timers.clearInterval;
+declare const console: __console.Console;
+declare const setTimeout: typeof __timers.setTimeout;
+declare const setInterval: typeof __timers.setInterval;
+declare const location: __domTypes.Location;
 declare const onload: Function | undefined;
+declare const onunload: Function | undefined;
 declare const crypto: Crypto;
-declare const Blob: typeof blob.DenoBlob;
-declare const File: domTypes.DomFileConstructor;
-declare const CustomEventInit: typeof customEvent.CustomEventInit;
-declare const CustomEvent: typeof customEvent.CustomEvent;
-declare const EventInit: typeof event.EventInit;
-declare const Event: typeof event.Event;
-declare const EventListener: typeof eventTarget.EventListener;
-declare const EventTarget: typeof eventTarget.EventTarget;
-declare const URL: typeof url.URL;
-declare const URLSearchParams: typeof urlSearchParams.URLSearchParams;
-declare const Headers: domTypes.HeadersConstructor;
-declare const FormData: domTypes.FormDataConstructor;
-declare const TextEncoder: typeof textEncoding.TextEncoder;
-declare const TextDecoder: typeof textEncoding.TextDecoder;
-declare const Request: domTypes.RequestConstructor;
-declare const Response: typeof fetchTypes.Response;
-declare const performance: performanceUtil.Performance;
+declare const Blob: typeof __blob.DenoBlob;
+declare const File: __domTypes.DomFileConstructor;
+declare const CustomEventInit: typeof __customEvent.CustomEventInit;
+declare const CustomEvent: typeof __customEvent.CustomEvent;
+declare const EventInit: typeof __event.EventInit;
+declare const Event: typeof __event.Event;
+declare const EventListener: typeof __eventTarget.EventListener;
+declare const EventTarget: typeof __eventTarget.EventTarget;
+declare const URL: typeof __url.URL;
+declare const URLSearchParams: typeof __urlSearchParams.URLSearchParams;
+declare const Headers: __domTypes.HeadersConstructor;
+declare const FormData: __domTypes.FormDataConstructor;
+declare const TextEncoder: typeof __textEncoding.TextEncoder;
+declare const TextDecoder: typeof __textEncoding.TextDecoder;
+declare const Request: __domTypes.RequestConstructor;
+declare const Response: typeof __fetch.Response;
+declare const performance: __performanceUtil.Performance;
 declare let onmessage: (e: { data: any }) => void;
-declare const workerMain: typeof workers.workerMain;
-declare const workerClose: typeof workers.workerClose;
-declare const postMessage: typeof workers.postMessage;
-declare const Worker: typeof workers.WorkerImpl;
+declare let onerror: (e: Event) => void;
+declare const workerMain: typeof __workers.workerMain;
+declare const workerClose: typeof __workers.workerClose;
+declare const postMessage: typeof __workers.postMessage;
+declare const Worker: typeof __workers.WorkerImpl;
 declare const addEventListener: (
   type: string,
-  callback: (event: domTypes.Event) => void | null,
-  options?: boolean | domTypes.AddEventListenerOptions | undefined
+  callback: (event: __domTypes.Event) => void | null,
+  options?: boolean | __domTypes.AddEventListenerOptions | undefined
 ) => void;
-declare const dispatchEvent: (event: domTypes.Event) => boolean;
+declare const dispatchEvent: (event: __domTypes.Event) => boolean;
 declare const removeEventListener: (
   type: string,
-  callback: (event: domTypes.Event) => void | null,
-  options?: boolean | domTypes.EventListenerOptions | undefined
+  callback: (event: __domTypes.Event) => void | null,
+  options?: boolean | __domTypes.EventListenerOptions | undefined
 ) => void;
 
-declare type Blob = blob.DenoBlob;
-declare type File = domTypes.DomFile;
-declare type CustomEventInit = customEvent.CustomEventInit;
-declare type CustomEvent = customEvent.CustomEvent;
-declare type EventInit = event.EventInit;
-declare type Event = event.Event;
-declare type EventListener = eventTarget.EventListener;
-declare type EventTarget = eventTarget.EventTarget;
-declare type URL = url.URL;
-declare type URLSearchParams = urlSearchParams.URLSearchParams;
-declare type Headers = domTypes.Headers;
-declare type FormData = domTypes.FormData;
-declare type TextEncoder = textEncoding.TextEncoder;
-declare type TextDecoder = textEncoding.TextDecoder;
-declare type Request = domTypes.Request;
-declare type Response = domTypes.Response;
-declare type Worker = workers.Worker;
+declare type Blob = __domTypes.Blob;
+declare type Body = __domTypes.Body;
+declare type File = __domTypes.DomFile;
+declare type CustomEventInit = __domTypes.CustomEventInit;
+declare type CustomEvent = __domTypes.CustomEvent;
+declare type EventInit = __domTypes.EventInit;
+declare type Event = __domTypes.Event;
+declare type EventListener = __domTypes.EventListener;
+declare type EventTarget = __domTypes.EventTarget;
+declare type URL = __url.URL;
+declare type URLSearchParams = __domTypes.URLSearchParams;
+declare type Headers = __domTypes.Headers;
+declare type FormData = __domTypes.FormData;
+declare type TextEncoder = __textEncoding.TextEncoder;
+declare type TextDecoder = __textEncoding.TextDecoder;
+declare type Request = __domTypes.Request;
+declare type Response = __domTypes.Response;
+declare type Worker = __workers.Worker;
 
 declare interface ImportMeta {
   url: string;
@@ -1282,7 +2264,9 @@ declare interface Crypto {
   ) => T;
 }
 
-declare namespace domTypes {
+declare namespace __domTypes {
+  // @url js/dom_types.d.ts
+
   export type BufferSource = ArrayBufferView | ArrayBuffer;
   export type HeadersInit =
     | Headers
@@ -1358,7 +2342,7 @@ declare namespace domTypes {
     loaded?: number;
     total?: number;
   }
-  export interface URLSearchParams {
+  export interface URLSearchParams extends DomIterable<string, string> {
     /**
      * Appends a specified key/value pair as a new search parameter.
      */
@@ -1400,7 +2384,7 @@ declare namespace domTypes {
      * and invokes the given function.
      */
     forEach(
-      callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+      callbackfn: (value: string, key: string, parent: this) => void,
       thisArg?: any
     ): void;
   }
@@ -1853,23 +2837,27 @@ declare namespace domTypes {
   }
 }
 
-declare namespace blob {
+declare namespace __blob {
+  // @url js/blob.d.ts
+
   export const bytesSymbol: unique symbol;
-  export const blobBytesWeakMap: WeakMap<domTypes.Blob, Uint8Array>;
-  export class DenoBlob implements domTypes.Blob {
+  export const blobBytesWeakMap: WeakMap<__domTypes.Blob, Uint8Array>;
+  export class DenoBlob implements __domTypes.Blob {
     private readonly [bytesSymbol];
     readonly size: number;
     readonly type: string;
     /** A blob object represents a file-like object of immutable, raw data. */
     constructor(
-      blobParts?: domTypes.BlobPart[],
-      options?: domTypes.BlobPropertyBag
+      blobParts?: __domTypes.BlobPart[],
+      options?: __domTypes.BlobPropertyBag
     );
     slice(start?: number, end?: number, contentType?: string): DenoBlob;
   }
 }
 
-declare namespace consoleTypes {
+declare namespace __console {
+  // @url js/console.d.ts
+
   type ConsoleOptions = Partial<{
     showHidden: boolean;
     depth: number;
@@ -1880,7 +2868,7 @@ declare namespace consoleTypes {
     static kClear: string;
     static kClearScreenDown: string;
   }
-  export const isConsoleInstance: unique symbol;
+  const isConsoleInstance: unique symbol;
   export class Console {
     private printFunc;
     indentLevel: number;
@@ -1901,6 +2889,27 @@ declare namespace consoleTypes {
         indentLevel: number;
       }>
     ) => void;
+
+    /** From MDN:
+     * Displays an interactive tree of the descendant elements of
+     * the specified XML/HTML element. If it is not possible to display
+     * as an element the JavaScript Object view is shown instead.
+     * The output is presented as a hierarchical listing of expandable
+     * nodes that let you see the contents of child nodes.
+     *
+     * Since we write to stdout, we can't display anything interactive
+     * we just fall back to `console.dir`.
+     */
+    dirxml: (
+      obj: unknown,
+      options?: Partial<{
+        showHidden: boolean;
+        depth: number;
+        colors: boolean;
+        indentLevel: number;
+      }>
+    ) => void;
+
     /** Writes the arguments to stdout */
     warn: (...args: unknown[]) => void;
     /** Writes the arguments to stdout */
@@ -1935,9 +2944,11 @@ declare namespace consoleTypes {
   export function inspect(value: unknown, options?: ConsoleOptions): string;
 }
 
-declare namespace event {
+declare namespace __event {
+  // @url js/event.d.ts
+
   export const eventAttributes: WeakMap<object, any>;
-  export class EventInit implements domTypes.EventInit {
+  export class EventInit implements __domTypes.EventInit {
     bubbles: boolean;
     cancelable: boolean;
     composed: boolean;
@@ -1951,7 +2962,7 @@ declare namespace event {
       composed?: boolean | undefined;
     });
   }
-  export class Event implements domTypes.Event {
+  export class Event implements __domTypes.Event {
     isTrusted: boolean;
     private _canceledFlag;
     private _dispatchedFlag;
@@ -1960,21 +2971,21 @@ declare namespace event {
     private _stopImmediatePropagationFlag;
     private _stopPropagationFlag;
     private _path;
-    constructor(type: string, eventInitDict?: domTypes.EventInit);
+    constructor(type: string, eventInitDict?: __domTypes.EventInit);
     readonly bubbles: boolean;
     cancelBubble: boolean;
     cancelBubbleImmediately: boolean;
     readonly cancelable: boolean;
     readonly composed: boolean;
-    currentTarget: domTypes.EventTarget;
+    currentTarget: __domTypes.EventTarget;
     readonly defaultPrevented: boolean;
     dispatched: boolean;
     eventPhase: number;
     readonly initialized: boolean;
     inPassiveListener: boolean;
-    path: domTypes.EventPath[];
-    relatedTarget: domTypes.EventTarget;
-    target: domTypes.EventTarget;
+    path: __domTypes.EventPath[];
+    relatedTarget: __domTypes.EventTarget;
+    target: __domTypes.EventTarget;
     readonly timeStamp: Date;
     readonly type: string;
     /** Returns the event’s path (objects on which listeners will be
@@ -1983,7 +2994,7 @@ declare namespace event {
      *
      *      event.composedPath();
      */
-    composedPath(): domTypes.EventPath[];
+    composedPath(): __domTypes.EventPath[];
     /** Cancels the event (if it is cancelable).
      * See https://dom.spec.whatwg.org/#set-the-canceled-flag
      *
@@ -2006,20 +3017,23 @@ declare namespace event {
   }
 }
 
-declare namespace customEvent {
+declare namespace __customEvent {
+  // @url js/custom_event.d.ts
+
   export const customEventAttributes: WeakMap<object, any>;
-  export class CustomEventInit extends event.EventInit
-    implements domTypes.CustomEventInit {
+  export class CustomEventInit extends __event.EventInit
+    implements __domTypes.CustomEventInit {
     detail: any;
     constructor({
       bubbles,
       cancelable,
       composed,
       detail
-    }: domTypes.CustomEventInit);
+    }: __domTypes.CustomEventInit);
   }
-  export class CustomEvent extends event.Event implements domTypes.CustomEvent {
-    constructor(type: string, customEventInitDict?: domTypes.CustomEventInit);
+  export class CustomEvent extends __event.Event
+    implements __domTypes.CustomEvent {
+    constructor(type: string, customEventInitDict?: __domTypes.CustomEventInit);
     readonly detail: any;
     initCustomEvent(
       type: string,
@@ -2031,14 +3045,16 @@ declare namespace customEvent {
   }
 }
 
-declare namespace eventTarget {
-  export class EventListenerOptions implements domTypes.EventListenerOptions {
+declare namespace __eventTarget {
+  // @url js/event_target.d.ts
+
+  export class EventListenerOptions implements __domTypes.EventListenerOptions {
     _capture: boolean;
     constructor({ capture }?: { capture?: boolean | undefined });
     readonly capture: boolean;
   }
   export class AddEventListenerOptions extends EventListenerOptions
-    implements domTypes.AddEventListenerOptions {
+    implements __domTypes.AddEventListenerOptions {
     _passive: boolean;
     _once: boolean;
     constructor({
@@ -2053,50 +3069,49 @@ declare namespace eventTarget {
     readonly passive: boolean;
     readonly once: boolean;
   }
-  export class EventListener implements domTypes.EventListener {
-    allEvents: domTypes.Event[];
-    atEvents: domTypes.Event[];
-    bubbledEvents: domTypes.Event[];
-    capturedEvents: domTypes.Event[];
+  export class EventListener implements __domTypes.EventListener {
+    allEvents: __domTypes.Event[];
+    atEvents: __domTypes.Event[];
+    bubbledEvents: __domTypes.Event[];
+    capturedEvents: __domTypes.Event[];
     private _callback;
     private _options;
     constructor(
-      callback: (event: domTypes.Event) => void | null,
-      options: boolean | domTypes.AddEventListenerOptions
+      callback: (event: __domTypes.Event) => void | null,
+      options: boolean | __domTypes.AddEventListenerOptions
     );
-    handleEvent(event: domTypes.Event): void;
-    readonly callback: (event: domTypes.Event) => void | null;
-    readonly options: domTypes.AddEventListenerOptions | boolean;
+    handleEvent(event: __domTypes.Event): void;
+    readonly callback: (event: __domTypes.Event) => void | null;
+    readonly options: __domTypes.AddEventListenerOptions | boolean;
   }
   export const eventTargetAssignedSlot: unique symbol;
   export const eventTargetHasActivationBehavior: unique symbol;
-  export class EventTarget implements domTypes.EventTarget {
-    [domTypes.eventTargetHost]: domTypes.EventTarget | null;
-    [domTypes.eventTargetListeners]: {
-      [type in string]: domTypes.EventListener[]
+  export class EventTarget implements __domTypes.EventTarget {
+    [__domTypes.eventTargetHost]: __domTypes.EventTarget | null;
+    [__domTypes.eventTargetListeners]: {
+      [type in string]: __domTypes.EventListener[];
     };
-    [domTypes.eventTargetMode]: string;
-    [domTypes.eventTargetNodeType]: domTypes.NodeType;
+    [__domTypes.eventTargetMode]: string;
+    [__domTypes.eventTargetNodeType]: __domTypes.NodeType;
     private [eventTargetAssignedSlot];
     private [eventTargetHasActivationBehavior];
     addEventListener(
       type: string,
-      callback: (event: domTypes.Event) => void | null,
-      options?: domTypes.AddEventListenerOptions | boolean
+      callback: (event: __domTypes.Event) => void | null,
+      options?: __domTypes.AddEventListenerOptions | boolean
     ): void;
     removeEventListener(
       type: string,
-      callback: (event: domTypes.Event) => void | null,
-      options?: domTypes.EventListenerOptions | boolean
+      callback: (event: __domTypes.Event) => void | null,
+      options?: __domTypes.EventListenerOptions | boolean
     ): void;
-    dispatchEvent(event: domTypes.Event): boolean;
+    dispatchEvent(event: __domTypes.Event): boolean;
     readonly [Symbol.toStringTag]: string;
   }
 }
 
-declare namespace io {
-  export const EOF: null;
-  export type EOF = null;
+declare namespace __io {
+  /** UNSTABLE: maybe remove "SEEK_" prefix. Maybe capitalization wrong. */
   export enum SeekMode {
     SEEK_START = 0,
     SEEK_CURRENT = 1,
@@ -2120,10 +3135,10 @@ declare namespace io {
      *
      * Implementations must not retain `p`.
      */
-    read(p: Uint8Array): Promise<number | EOF>;
+    read(p: Uint8Array): Promise<number | Deno.EOF>;
   }
   export interface SyncReader {
-    readSync(p: Uint8Array): number | EOF;
+    readSync(p: Uint8Array): number | Deno.EOF;
   }
   export interface Writer {
     /** Writes `p.byteLength` bytes from `p` to the underlying data
@@ -2164,7 +3179,10 @@ declare namespace io {
   export interface WriteSeeker extends Writer, Seeker {}
   export interface ReadWriteCloser extends Reader, Writer, Closer {}
   export interface ReadWriteSeeker extends Reader, Writer, Seeker {}
-  /** Copies from `src` to `dst` until either `EOF` is reached on `src`
+
+  /** UNSTABLE: controversial.
+   *
+   * Copies from `src` to `dst` until either `EOF` is reached on `src`
    * or an error occurs. It returns the number of bytes copied and the first
    * error encountered while copying, if any.
    *
@@ -2172,7 +3190,10 @@ declare namespace io {
    * treat an `EOF` from `read()` as an error to be reported.
    */
   export function copy(dst: Writer, src: Reader): Promise<number>;
-  /** Turns `r` into async iterator.
+
+  /** UNSTABLE: Make Reader into AsyncIterable? Remove this?
+   *
+   * Turns `r` into async iterator.
    *
    *      for await (const chunk of toAsyncIterator(reader)) {
    *          console.log(chunk)
@@ -2181,8 +3202,11 @@ declare namespace io {
   export function toAsyncIterator(r: Reader): AsyncIterableIterator<Uint8Array>;
 }
 
-declare namespace fetchTypes {
-  class Body implements domTypes.Body, domTypes.ReadableStream, io.ReadCloser {
+declare namespace __fetch {
+  // @url js/fetch.d.ts
+
+  class Body
+    implements __domTypes.Body, __domTypes.ReadableStream, __io.ReadCloser {
     private rid;
     readonly contentType: string;
     bodyUsed: boolean;
@@ -2193,25 +3217,25 @@ declare namespace fetchTypes {
     constructor(rid: number, contentType: string);
     private _bodyBuffer;
     arrayBuffer(): Promise<ArrayBuffer>;
-    blob(): Promise<domTypes.Blob>;
-    formData(): Promise<domTypes.FormData>;
+    blob(): Promise<__domTypes.Blob>;
+    formData(): Promise<__domTypes.FormData>;
     json(): Promise<any>;
     text(): Promise<string>;
-    read(p: Uint8Array): Promise<number | io.EOF>;
+    read(p: Uint8Array): Promise<number | Deno.EOF>;
     close(): void;
     cancel(): Promise<void>;
-    getReader(): domTypes.ReadableStreamReader;
-    tee(): [domTypes.ReadableStream, domTypes.ReadableStream];
+    getReader(): __domTypes.ReadableStreamReader;
+    tee(): [__domTypes.ReadableStream, __domTypes.ReadableStream];
     [Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array>;
   }
-  export class Response implements domTypes.Response {
+  export class Response implements __domTypes.Response {
     readonly url: string;
     readonly status: number;
     statusText: string;
     readonly type = "basic";
     readonly redirected: boolean;
-    headers: domTypes.Headers;
-    readonly trailer: Promise<domTypes.Headers>;
+    headers: __domTypes.Headers;
+    readonly trailer: Promise<__domTypes.Headers>;
     bodyUsed: boolean;
     readonly body: Body;
     constructor(
@@ -2223,21 +3247,23 @@ declare namespace fetchTypes {
       body_?: null | Body
     );
     arrayBuffer(): Promise<ArrayBuffer>;
-    blob(): Promise<domTypes.Blob>;
-    formData(): Promise<domTypes.FormData>;
+    blob(): Promise<__domTypes.Blob>;
+    formData(): Promise<__domTypes.FormData>;
     json(): Promise<any>;
     text(): Promise<string>;
     readonly ok: boolean;
-    clone(): domTypes.Response;
+    clone(): __domTypes.Response;
   }
   /** Fetch a resource from the network. */
   export function fetch(
-    input: domTypes.Request | string,
-    init?: domTypes.RequestInit
+    input: __domTypes.Request | __url.URL | string,
+    init?: __domTypes.RequestInit
   ): Promise<Response>;
 }
 
-declare namespace textEncoding {
+declare namespace __textEncoding {
+  // @url js/text_encoding.d.ts
+
   export function atob(s: string): string;
   /** Creates a base-64 ASCII string from the input string. */
   export function btoa(s: string): string;
@@ -2246,7 +3272,7 @@ declare namespace textEncoding {
   }
   export interface TextDecoderOptions {
     fatal?: boolean;
-    ignoreBOM?: false;
+    ignoreBOM?: boolean;
   }
   export class TextDecoder {
     private _encoding;
@@ -2258,7 +3284,10 @@ declare namespace textEncoding {
     readonly ignoreBOM = false;
     constructor(label?: string, options?: TextDecoderOptions);
     /** Returns the result of running encoding's decoder. */
-    decode(input?: domTypes.BufferSource, options?: TextDecodeOptions): string;
+    decode(
+      input?: __domTypes.BufferSource,
+      options?: TextDecodeOptions
+    ): string;
     readonly [Symbol.toStringTag]: string;
   }
   interface TextEncoderEncodeIntoResult {
@@ -2275,7 +3304,9 @@ declare namespace textEncoding {
   }
 }
 
-declare namespace timers {
+declare namespace __timers {
+  // @url js/timers.d.ts
+
   export type Args = unknown[];
   /** Sets a timer which executes a function once after the timer expires. */
   export function setTimeout(
@@ -2293,7 +3324,9 @@ declare namespace timers {
   export function clearInterval(id?: number): void;
 }
 
-declare namespace urlSearchParams {
+declare namespace __urlSearchParams {
+  // @url js/url_search_params.d.ts
+
   export class URLSearchParams {
     private params;
     private url;
@@ -2353,7 +3386,7 @@ declare namespace urlSearchParams {
      *
      */
     forEach(
-      callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+      callbackfn: (value: string, key: string, parent: this) => void,
       thisArg?: any
     ): void;
     /** Returns an iterator allowing to go through all keys contained
@@ -2363,7 +3396,7 @@ declare namespace urlSearchParams {
      *         console.log(key);
      *       }
      */
-    keys(): Iterable<string>;
+    keys(): IterableIterator<string>;
     /** Returns an iterator allowing to go through all values contained
      * in this object.
      *
@@ -2371,7 +3404,7 @@ declare namespace urlSearchParams {
      *         console.log(value);
      *       }
      */
-    values(): Iterable<string>;
+    values(): IterableIterator<string>;
     /** Returns an iterator allowing to go through all key/value
      * pairs contained in this object.
      *
@@ -2379,7 +3412,7 @@ declare namespace urlSearchParams {
      *         console.log(key, value);
      *       }
      */
-    entries(): Iterable<[string, string]>;
+    entries(): IterableIterator<[string, string]>;
     /** Returns an iterator allowing to go through all key/value
      * pairs contained in this object.
      *
@@ -2387,7 +3420,7 @@ declare namespace urlSearchParams {
      *         console.log(key, value);
      *       }
      */
-    [Symbol.iterator](): Iterable<[string, string]>;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
     /** Returns a query string suitable for use in a URL.
      *
      *        searchParams.toString();
@@ -2398,12 +3431,9 @@ declare namespace urlSearchParams {
   }
 }
 
-declare namespace url {
-  export const blobURLMap: Map<string, domTypes.Blob>;
-  export class URL {
-    private _parts;
-    private _searchParams;
-    private _updateSearchParams;
+declare namespace __url {
+  // @url js/url.d.ts
+  export interface URL {
     hash: string;
     host: string;
     hostname: string;
@@ -2414,17 +3444,23 @@ declare namespace url {
     port: string;
     protocol: string;
     search: string;
+    readonly searchParams: __urlSearchParams.URLSearchParams;
     username: string;
-    readonly searchParams: urlSearchParams.URLSearchParams;
-    constructor(url: string, base?: string | URL);
     toString(): string;
     toJSON(): string;
-    static createObjectURL(b: domTypes.Blob): string;
-    static revokeObjectURL(url: string): void;
   }
+
+  export const URL: {
+    prototype: URL;
+    new (url: string, base?: string | URL): URL;
+    createObjectURL(object: __domTypes.Blob): string;
+    revokeObjectURL(url: string): void;
+  };
 }
 
-declare namespace workers {
+declare namespace __workers {
+  // @url js/workers.d.ts
+
   export function encodeMessage(data: any): Uint8Array;
   export function decodeMessage(dataIntArray: Uint8Array): any;
   export let onmessage: (e: { data: any }) => void;
@@ -2434,7 +3470,7 @@ declare namespace workers {
   export function workerClose(): void;
   export function workerMain(): Promise<void>;
   export interface Worker {
-    onerror?: () => void;
+    onerror?: (e: Event) => void;
     onmessage?: (e: { data: any }) => void;
     onmessageerror?: () => void;
     postMessage(data: any): void;
@@ -2449,10 +3485,10 @@ declare namespace workers {
     noDenoNamespace?: boolean;
   }
   export class WorkerImpl implements Worker {
-    private readonly rid;
+    private readonly id;
     private isClosing;
     private readonly isClosedPromise;
-    onerror?: () => void;
+    onerror?: (e: Event) => void;
     onmessage?: (data: any) => void;
     onmessageerror?: () => void;
     constructor(specifier: string, options?: DenoWorkerOptions);
@@ -2462,7 +3498,9 @@ declare namespace workers {
   }
 }
 
-declare namespace performanceUtil {
+declare namespace __performanceUtil {
+  // @url js/performance.d.ts
+
   export class Performance {
     /** Returns a current time from Deno's start in milliseconds.
      *
@@ -2474,6 +3512,8 @@ declare namespace performanceUtil {
     now(): number;
   }
 }
+
+// @url js/lib.web_assembly.d.ts
 
 // This follows the WebIDL at: https://webassembly.github.io/spec/js-api/
 // And follow on WebIDL at: https://webassembly.github.io/spec/web-api/
@@ -2490,14 +3530,14 @@ declare namespace WebAssembly {
    * function is useful if it is necessary to a compile a module before it can
    * be instantiated (otherwise, the `WebAssembly.instantiate()` function
    * should be used). */
-  function compile(bufferSource: domTypes.BufferSource): Promise<Module>;
+  function compile(bufferSource: __domTypes.BufferSource): Promise<Module>;
 
   /** Compiles a `WebAssembly.Module` directly from a streamed underlying
    * source. This function is useful if it is necessary to a compile a module
    * before it can be instantiated (otherwise, the
    * `WebAssembly.instantiateStreaming()` function should be used). */
   function compileStreaming(
-    source: Promise<domTypes.Response>
+    source: Promise<__domTypes.Response>
   ): Promise<Module>;
 
   /** Takes the WebAssembly binary code, in the form of a typed array or
@@ -2505,7 +3545,7 @@ declare namespace WebAssembly {
    * The returned `Promise` resolves to both a compiled `WebAssembly.Module` and
    * its first `WebAssembly.Instance`. */
   function instantiate(
-    bufferSource: domTypes.BufferSource,
+    bufferSource: __domTypes.BufferSource,
     importObject?: object
   ): Promise<WebAssemblyInstantiatedSource>;
 
@@ -2521,13 +3561,13 @@ declare namespace WebAssembly {
    * underlying source. This is the most efficient, optimized way to load wasm
    * code. */
   function instantiateStreaming(
-    source: Promise<domTypes.Response>,
+    source: Promise<__domTypes.Response>,
     importObject?: object
   ): Promise<WebAssemblyInstantiatedSource>;
 
   /** Validates a given typed array of WebAssembly binary code, returning
    * whether the bytes form a valid wasm module (`true`) or not (`false`). */
-  function validate(bufferSource: domTypes.BufferSource): boolean;
+  function validate(bufferSource: __domTypes.BufferSource): boolean;
 
   type ImportExportKind = "function" | "table" | "memory" | "global";
 
@@ -2542,7 +3582,7 @@ declare namespace WebAssembly {
   }
 
   class Module {
-    constructor(bufferSource: domTypes.BufferSource);
+    constructor(bufferSource: __domTypes.BufferSource);
 
     /** Given a `Module` and string, returns a copy of the contents of all
      * custom sections in the module with the given string name. */
@@ -2647,5 +3687,11 @@ declare namespace WebAssembly {
   }
 }
 
-/* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
+// Catch-all for JSX elements.
+// See https://www.typescriptlang.org/docs/handbook/jsx.html#intrinsic-elements
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}
 


### PR DESCRIPTION
This plugin was stripping the extension too early (and assuming only ts extension) causing problems. This fixes those issues.
Now `.js/.jsx/.tsx` etc extensions are supported.

Resolves: https://github.com/justjavac/typescript-deno-plugin/issues/21
