### PR TITLE
Fix collection updating and undefined error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,9 +240,11 @@ module.exports = function init(
           return getScriptFileNames.call(tsLsHost);
         }
 
-        const scriptFileNames = getScriptFileNames.call(
+        const originalScriptFileNames = getScriptFileNames.call(
           info.languageServiceHost,
         );
+
+        const scriptFileNames = [... originalScriptFileNames];
 
         const libDenoDts = getDenoDtsPath(tsLsHost, "lib.deno.d.ts");
         if (!libDenoDts) {
@@ -429,6 +431,8 @@ module.exports = function init(
 
         for (const errorCode of errorCodes) {
           const fixes = errorCodeToFixes.get(errorCode)!
+          if (fixes == null) continue;
+
           for (const fix of fixes) {
             fix.replaceCodeActions(codeFixActions);
           }


### PR DESCRIPTION
1. We shouldn't change collection from the original method because it can produce unexpected behaviour (the original collection is cached in the host).
2. Fix "object is undefined" error for fixes not from the map

Fun fact: I reported similar to (1) issue several years ago for "tslint-typescript-plugin"
angelozerr/tslint-language-service#41