### PR TITLE
make getPluginPath resolve relative to __dirname

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,14 +246,14 @@ module.exports = function init(
 
         const scriptFileNames = [... originalScriptFileNames];
 
-        const libDenoDts = getDenoDtsPath(tsLsHost, "lib.deno.d.ts");
+        const libDenoDts = getDenoDtsPath("lib.deno.d.ts");
         if (!libDenoDts) {
           logger.info(`Can not load lib.deno.d.ts from ${libDenoDts}.`);
           return scriptFileNames;
         }
         scriptFileNames.push(libDenoDts);
 
-        const libWebworkerDts = getDenoDtsPath(tsLsHost, "lib.webworker.d.ts");
+        const libWebworkerDts = getDenoDtsPath("lib.webworker.d.ts");
         if (!libWebworkerDts) {
           logger.info(
             `Can not load lib.webworker.d.ts from ${libWebworkerDts}.`,

--- a/src/typescript_host.ts
+++ b/src/typescript_host.ts
@@ -99,7 +99,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
   getScriptFileNames(): string[] {
     const scriptFileNames: string[] = this.tsLsHost.getScriptFileNames();
 
-    const denoDtsPath = getDenoDtsPath(this.tsLsHost, "lib.deno.d.ts");
+    const denoDtsPath = getDenoDtsPath("lib.deno.d.ts");
 
     if (denoDtsPath) {
       scriptFileNames.push(denoDtsPath);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,14 +43,8 @@ export function isInDenoDir(filepath: string): boolean {
   return filepath.startsWith(denoDir);
 }
 
-export function getPluginPath(
-  tsLsHost: ts.LanguageServiceHost,
-): string {
-  return path.resolve(
-    tsLsHost.getCurrentDirectory(),
-    "node_modules",
-    "typescript-deno-plugin",
-  );
+export function getPluginPath(): string {
+  return path.resolve(__dirname, "..");
 }
 
 export function getDenoDtsPath(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,7 @@ export function getDenoDtsPath(
     return file;
   }
 
-  file = path.resolve(getPluginPath(tsLsHost), "lib", specifier);
+  file = path.resolve(getPluginPath(), "lib", specifier);
   if (fs.existsSync(file)) {
     return file;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,6 @@ import * as path from "path";
 import crypto from "crypto";
 import { URL } from "url";
 
-import ts from "typescript/lib/tsserverlibrary";
-
 export function getDenoDir(): string {
   // ref https://deno.land/manual.html
   // On Linux/Redox: $XDG_CACHE_HOME/deno or $HOME/.cache/deno
@@ -48,7 +46,6 @@ export function getPluginPath(): string {
 }
 
 export function getDenoDtsPath(
-  tsLsHost: ts.LanguageServiceHost,
   specifier: string,
 ): string | undefined {
   let file: string = path.resolve(getDenoDir(), specifier);


### PR DESCRIPTION
<!--

Thank you for being interested in typescript-deno-plugin!

Have you read typescript-deno-plugin's Code of Conduct? https://github.com/justjavac/typescript-deno-plugin/blob/master/CODE_OF_CONDUCT.md

Before making a PR, please read our contributing guidelines
https://github.com/justjavac/typescript-deno-plugin/blob/master/CONTRIBUTING.md

-->

By using `__dirname` rather than `tsLsHost.getCurrentDirectory()`, `getPluginPath()` will return the correct path regardless of where the plugin is installed (global or local).

Fixes: #43 