### PR TITLE
Feat #48 import auto complete

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,0 +1,190 @@
+import {
+    GetCompletionsAtPositionOptions,
+    LanguageService,
+    ScriptElementKind,
+    CompletionEntry,
+} from "typescript/lib/tsserverlibrary";
+import { TsUtils } from "./ts-utils";
+import {
+    getDenoDir,
+    parseImportMapFromFile,
+} from "./utils";
+import { readdirSync, statSync } from 'fs';
+import { ImportMaps } from "import-maps";
+import { join } from 'path';
+
+const importPathSanitizeRegex = /^\ ?['"](.*)['"]$/;
+
+interface ImportPath {
+    path: string;
+    isDir: boolean;
+}
+
+export default function getCompletionsAtPositionWrapper(projectDirectory: string, config: any, tsLs: LanguageService, tsUtils: TsUtils) {
+    function getCompletionsAtPosition(fileName: string, position: number, options: GetCompletionsAtPositionOptions) {
+        const node = tsUtils.getNode(fileName, position);
+        if (!node) {
+            return tsLs.getCompletionsAtPosition(fileName, position, options);
+        }
+
+        // 254 === ImportDeclaration
+        // 10 === StringLiteral
+        if (node.parent.kind !== 254 || node.kind !== 10) {
+            return tsLs.getCompletionsAtPosition(fileName, position, options);
+        }
+
+        const importMap = parseImportMapFromFile(projectDirectory, config.importmap)['imports'];
+        const importPath = tsUtils.getNodeText(node, fileName);
+
+        const sanitizedImportPath = (importPathSanitizeRegex.exec(importPath) as string[])[1];
+
+        const importMapCompletions = getImportMapCompletions(sanitizedImportPath, importMap);
+
+        const importMappedPath = applyImportMap(sanitizedImportPath , importMap);
+        const completions = getPathCompletions(importMappedPath, fileName);
+        
+        return { 
+            isGlobalCompletion: false,
+            isMemberCompletion: true,
+            isNewIdentifierLocation: false,
+            entries: [...completions, ...importMapCompletions],
+        };;
+    };
+
+  return getCompletionsAtPosition;
+}
+
+const httpRegex = /^https?:\/\//;
+const relativeRegex = /\.\.?\//;
+
+function getPathCompletions(path: string, fileName: string) {
+    const lastPath = path.substr(path.lastIndexOf('/') + 1);
+    const basePath = path.substring(0, path.length - lastPath.length);
+
+    const denoDir = getDenoDir();
+
+    const importPaths: ImportPath[] = [];
+
+    if (httpRegex.test(basePath)) {
+        importPaths.push(...getHttpImportPaths(basePath, denoDir));
+    }
+
+    if (relativeRegex.test(basePath)) {
+        importPaths.push(...getRelativeImportPaths(fileName, basePath));
+    }
+
+    const completions: CompletionEntry[]  = [];
+    
+    for (const importPath of importPaths) {
+        const {
+            path,
+            isDir,
+        } = importPath
+        if (path.startsWith(lastPath)) {
+            completions.push({
+                name: path.slice(lastPath.length),
+                kind: isDir ? ScriptElementKind.directory : ScriptElementKind.scriptElement,
+                sortText: '',
+                kindModifiers: isDir ? '' : '.ts',
+            });
+        }
+    }
+
+    return completions;
+}
+
+function getRelativeImportPaths(fileName: string, relativePath: string) {
+    const basePath = fileName.substr(0, fileName.lastIndexOf('/'));
+    const path = join(basePath, relativePath);
+    const importPaths = getImportPathsFromDir(path)
+        .filter(importPath => {
+            if (importPath.isDir) {
+                return true;
+            }
+            
+            return importPath.path.endsWith('.ts');
+        });
+    return importPaths;
+}
+
+function applyImportMap(path: string, importMap: ImportMaps['imports']) {
+    for (const importMapEntry of Object.keys(importMap)) {
+        if (!path.startsWith(importMapEntry)) {
+            continue;
+        }
+        let importMapPath = importMap[importMapEntry];
+        if (importMapPath === null) {
+            continue;
+        }
+        if (typeof importMapPath === 'object') {
+            importMapPath = importMapPath.toString();
+        }
+
+        return importMapPath  + path.slice(importMapEntry.length);
+    }
+
+    return path;
+}
+
+function getHttpImportPaths(basePath: string, denoDir: string) {
+    const url = basePath.replace(httpRegex, '');
+    const baseDir = `${denoDir}/gen/https/${url}`;
+    const importPaths: ImportPath[] = getImportPathsFromDir(baseDir)
+        .filter(importPath => {
+            if (importPath.isDir) {
+                return true;
+            }
+            if (importPath.path.endsWith('.js') || importPath.path.endsWith('.js.map')) {
+                return false;
+            }
+
+            return true;
+        })
+        .map(importPath => {
+            if (!importPath.isDir) {
+                // importPath.path === xxx.ts.meta
+                importPath.path = importPath.path.slice(0, importPath.path.length - 5);
+            }
+
+            return importPath;
+        });
+
+    return importPaths;
+}
+
+
+
+function getImportPathsFromDir(dir: string): ImportPath[] {
+    try {
+        const importPaths: ImportPath[] = []
+        const importPathFiles = readdirSync(dir);
+        for (const importPathFile of importPathFiles) {
+            const fileStats = statSync(`${dir}/${importPathFile}`);
+            importPaths.push({
+                path: importPathFile,
+                isDir: fileStats.isDirectory(),
+            });
+        }
+
+        return importPaths;
+    } catch {
+        return []
+    }
+}
+
+function getImportMapCompletions(importPath: string, importMap: ImportMaps['imports']) {
+    const importMapEntries = Object.keys(importMap);
+    const completions: CompletionEntry[] = []
+
+    for (const importMapEntry of importMapEntries) {
+        if (importMapEntry.startsWith(importPath)) {
+            completions.push({
+                name: importMapEntry.slice(importPath.length),
+                kind: ScriptElementKind.directory,
+                sortText: '',
+            })
+        }
+    }
+
+    return completions;
+}

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,13 +1,13 @@
 import {
-    GetCompletionsAtPositionOptions,
-    LanguageService,
-    ScriptElementKind,
-    CompletionEntry,
+	GetCompletionsAtPositionOptions,
+	LanguageService,
+	ScriptElementKind,
+	CompletionEntry,
 } from "typescript/lib/tsserverlibrary";
 import { TsUtils } from "./ts-utils";
 import {
-    getDenoDir,
-    parseImportMapFromFile,
+	getDenoDir,
+	parseImportMapFromFile,
 } from "./utils";
 import { readdirSync, statSync } from 'fs';
 import { ImportMaps } from "import-maps";
@@ -16,175 +16,177 @@ import { join } from 'path';
 const importPathSanitizeRegex = /^\ ?['"](.*)['"]$/;
 
 interface ImportPath {
-    path: string;
-    isDir: boolean;
+	path: string;
+	isDir: boolean;
 }
 
 export default function getCompletionsAtPositionWrapper(projectDirectory: string, config: any, tsLs: LanguageService, tsUtils: TsUtils) {
-    function getCompletionsAtPosition(fileName: string, position: number, options: GetCompletionsAtPositionOptions) {
-        const node = tsUtils.getNode(fileName, position);
-        if (!node) {
-            return tsLs.getCompletionsAtPosition(fileName, position, options);
-        }
+	function getCompletionsAtPosition(fileName: string, position: number, options: GetCompletionsAtPositionOptions) {
+		const node = tsUtils.getNode(fileName, position);
+		if (!node) {
+			return tsLs.getCompletionsAtPosition(fileName, position, options);
+		}
 
-        // 254 === ImportDeclaration
-        // 10 === StringLiteral
-        if (node.parent.kind !== 254 || node.kind !== 10) {
-            return tsLs.getCompletionsAtPosition(fileName, position, options);
-        }
+		// 254 === ImportDeclaration
+		// 10 === StringLiteral
+		if (node.parent.kind !== 254 || node.kind !== 10) {
+			return tsLs.getCompletionsAtPosition(fileName, position, options);
+		}
 
-        const importMap = parseImportMapFromFile(projectDirectory, config.importmap)['imports'];
-        const importPath = tsUtils.getNodeText(node, fileName);
+		const importMap = parseImportMapFromFile(projectDirectory, config.importmap)['imports'];
+		const importPath = tsUtils.getNodeText(node, fileName);
 
-        const sanitizedImportPath = (importPathSanitizeRegex.exec(importPath) as string[])[1];
+		const sanitizedImportPath = (importPathSanitizeRegex.exec(importPath) as string[])[1];
 
-        const importMapCompletions = getImportMapCompletions(sanitizedImportPath, importMap);
+		const importMapCompletions = getImportMapCompletions(sanitizedImportPath, importMap);
 
-        const importMappedPath = applyImportMap(sanitizedImportPath , importMap);
-        const completions = getPathCompletions(importMappedPath, fileName);
-        
-        return { 
-            isGlobalCompletion: false,
-            isMemberCompletion: true,
-            isNewIdentifierLocation: false,
-            entries: [...completions, ...importMapCompletions],
-        };;
-    };
+		const importMappedPath = applyImportMap(sanitizedImportPath , importMap);
+		const completions = getPathCompletions(importMappedPath, fileName);
+		
+		return { 
+			isGlobalCompletion: false,
+			isMemberCompletion: true,
+			isNewIdentifierLocation: false,
+			entries: [...completions, ...importMapCompletions],
+		}
+	};
 
-  return getCompletionsAtPosition;
+	return getCompletionsAtPosition;
 }
 
 const httpRegex = /^https?:\/\//;
 const relativeRegex = /\.\.?\//;
 
 function getPathCompletions(path: string, fileName: string) {
-    const lastPath = path.substr(path.lastIndexOf('/') + 1);
-    const basePath = path.substring(0, path.length - lastPath.length);
+	const lastPath = path.substr(path.lastIndexOf('/') + 1);
+	const basePath = path.substring(0, path.length - lastPath.length);
 
-    const denoDir = getDenoDir();
+	const denoDir = getDenoDir();
 
-    const importPaths: ImportPath[] = [];
+	const importPaths: ImportPath[] = [];
 
-    if (httpRegex.test(basePath)) {
-        importPaths.push(...getHttpImportPaths(basePath, denoDir));
-    }
+	if (httpRegex.test(basePath)) {
+		importPaths.push(...getHttpImportPaths(basePath, denoDir));
+	}
 
-    if (relativeRegex.test(basePath)) {
-        importPaths.push(...getRelativeImportPaths(fileName, basePath));
-    }
+	if (relativeRegex.test(basePath)) {
+		importPaths.push(...getRelativeImportPaths(fileName, basePath));
+	}
 
-    const completions: CompletionEntry[]  = [];
-    
-    for (const importPath of importPaths) {
-        const {
-            path,
-            isDir,
-        } = importPath
-        if (path.startsWith(lastPath)) {
-            completions.push({
-                name: path.slice(lastPath.length),
-                kind: isDir ? ScriptElementKind.directory : ScriptElementKind.scriptElement,
-                sortText: '',
-                kindModifiers: isDir ? '' : '.ts',
-            });
-        }
-    }
+	const completions: CompletionEntry[]  = [];
 
-    return completions;
+	for (const importPath of importPaths) {
+		const {
+			path,
+			isDir,
+		} = importPath;
+
+		if (path.startsWith(lastPath)) {
+			completions.push({
+				name: path.slice(lastPath.length),
+				kind: isDir ? ScriptElementKind.directory : ScriptElementKind.scriptElement,
+				sortText: '',
+				kindModifiers: isDir ? '' : '.ts',
+			});
+		}
+	}
+
+	return completions;
 }
 
 function getRelativeImportPaths(fileName: string, relativePath: string) {
-    const basePath = fileName.substr(0, fileName.lastIndexOf('/'));
-    const path = join(basePath, relativePath);
-    const importPaths = getImportPathsFromDir(path)
-        .filter(importPath => {
-            if (importPath.isDir) {
-                return true;
-            }
-            
-            return importPath.path.endsWith('.ts');
-        });
-    return importPaths;
+	const basePath = fileName.substr(0, fileName.lastIndexOf('/'));
+	const path = join(basePath, relativePath);
+	const importPaths = getImportPathsFromDir(path)
+		.filter(importPath => {
+			if (importPath.isDir) {
+				return true;
+			}
+			
+			return importPath.path.endsWith('.ts');
+		});
+		
+	return importPaths;
 }
 
 function applyImportMap(path: string, importMap: ImportMaps['imports']) {
-    for (const importMapEntry of Object.keys(importMap)) {
-        if (!path.startsWith(importMapEntry)) {
-            continue;
-        }
-        let importMapPath = importMap[importMapEntry];
-        if (importMapPath === null) {
-            continue;
-        }
-        if (typeof importMapPath === 'object') {
-            importMapPath = importMapPath.toString();
-        }
+	for (const importMapEntry of Object.keys(importMap)) {
+		if (!path.startsWith(importMapEntry)) {
+			continue;
+		}
+		let importMapPath = importMap[importMapEntry];
+		if (importMapPath === null) {
+			continue;
+		}
+		if (typeof importMapPath === 'object') {
+			importMapPath = importMapPath.toString();
+		}
 
-        return importMapPath  + path.slice(importMapEntry.length);
-    }
+		return importMapPath + path.slice(importMapEntry.length);
+	}
 
-    return path;
+	return path;
 }
 
 function getHttpImportPaths(basePath: string, denoDir: string) {
-    const url = basePath.replace(httpRegex, '');
-    const baseDir = `${denoDir}/gen/https/${url}`;
-    const importPaths: ImportPath[] = getImportPathsFromDir(baseDir)
-        .filter(importPath => {
-            if (importPath.isDir) {
-                return true;
-            }
-            if (importPath.path.endsWith('.js') || importPath.path.endsWith('.js.map')) {
-                return false;
-            }
+	const url = basePath.replace(httpRegex, '');
+	const baseDir = `${denoDir}/gen/https/${url}`;
+	const importPaths: ImportPath[] = getImportPathsFromDir(baseDir)
+		.filter(importPath => {
+			if (importPath.isDir) {
+				return true;
+			}
+			if (importPath.path.endsWith('.js') || importPath.path.endsWith('.js.map')) {
+				return false;
+			}
 
-            return true;
-        })
-        .map(importPath => {
-            if (!importPath.isDir) {
-                // importPath.path === xxx.ts.meta
-                importPath.path = importPath.path.slice(0, importPath.path.length - 5);
-            }
+			return true;
+		})
+		.map(importPath => {
+			if (!importPath.isDir) {
+				// importPath.path === xxx.ts.meta
+				importPath.path = importPath.path.slice(0, importPath.path.length - 5);
+			}
 
-            return importPath;
-        });
+			return importPath;
+		});
 
-    return importPaths;
+	return importPaths;
 }
 
 
 
 function getImportPathsFromDir(dir: string): ImportPath[] {
-    try {
-        const importPaths: ImportPath[] = []
-        const importPathFiles = readdirSync(dir);
-        for (const importPathFile of importPathFiles) {
-            const fileStats = statSync(`${dir}/${importPathFile}`);
-            importPaths.push({
-                path: importPathFile,
-                isDir: fileStats.isDirectory(),
-            });
-        }
+	try {
+		const importPaths: ImportPath[] = [];
+		const importPathFiles = readdirSync(dir);
+		for (const importPathFile of importPathFiles) {
+			const fileStats = statSync(`${dir}/${importPathFile}`);
+			importPaths.push({
+					path: importPathFile,
+					isDir: fileStats.isDirectory(),
+			});
+		}
 
-        return importPaths;
-    } catch {
-        return []
-    }
+		return importPaths;
+	} catch {
+		return [];
+	}
 }
 
 function getImportMapCompletions(importPath: string, importMap: ImportMaps['imports']) {
-    const importMapEntries = Object.keys(importMap);
-    const completions: CompletionEntry[] = []
+	const importMapEntries = Object.keys(importMap);
+	const completions: CompletionEntry[] = [];
 
-    for (const importMapEntry of importMapEntries) {
-        if (importMapEntry.startsWith(importPath)) {
-            completions.push({
-                name: importMapEntry.slice(importPath.length),
-                kind: ScriptElementKind.directory,
-                sortText: '',
-            })
-        }
-    }
+	for (const importMapEntry of importMapEntries) {
+		if (importMapEntry.startsWith(importPath)) {
+			completions.push({
+				name: importMapEntry.slice(importPath.length),
+				kind: ScriptElementKind.directory,
+				sortText: '',
+			});
+		}
+	}
 
-    return completions;
+	return completions;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 // modified from https://github.com/Microsoft/typescript-tslint-plugin
 import path from "path";
-import fs from "fs";
 import { URL, fileURLToPath } from "url";
 
 import merge from "merge-deep";
@@ -11,21 +10,22 @@ import ts_module, {
   FormatCodeSettings,
   CodeFixAction,
 } from "typescript/lib/tsserverlibrary";
-import { parseFromString, resolve, ImportMaps } from "import-maps";
+import { resolve, ImportMaps } from "import-maps";
 
 import { Logger } from "./logger";
 import {
   getDenoDtsPath,
-  normalizeFilepath,
-  pathExistsSync,
   isHttpURL,
   isInDenoDir,
+  parseImportMapFromFile,
 } from "./utils";
 
 import { universalModuleResolver } from "./module_resolver/universal_module_resolver";
 import { HashMeta } from "./module_resolver/hash_meta";
 import { errorCodeToFixes } from "./codefix_provider";
 import './code_fixes'
+import { getTsUtils } from './ts-utils';
+import getCompletionsAtPositionWrapper from "./completions";
 
 let logger: Logger;
 let pluginInfo: ts_module.server.PluginCreateInfo;
@@ -87,6 +87,8 @@ module.exports = function init(
       const tsLs = info.languageService;
       const tsLsHost = info.languageServiceHost;
       const project = info.project;
+
+      const tsUtils = getTsUtils(tsLs);
 
       Object.assign(config, info.config);
 
@@ -264,6 +266,8 @@ module.exports = function init(
 
         return scriptFileNames;
       };
+
+      const getCompletionsAtPosition = getCompletionsAtPositionWrapper(projectDirectory, config, tsLs, tsUtils);
 
       function getCompletionEntryDetails(
         fileName: string,
@@ -445,6 +449,7 @@ module.exports = function init(
         Object.create(null),
         tsLs,
         {
+          getCompletionsAtPosition,
           getCompletionEntryDetails,
           getSemanticDiagnostics,
           getCodeFixesAtPosition,
@@ -470,37 +475,6 @@ module.exports = function init(
     },
   };
 };
-
-function parseImportMapFromFile(cwd: string, file?: string): ImportMaps {
-  const importmps: ImportMaps = {
-    imports: {},
-    scopes: {},
-  };
-
-  if (file == null) {
-    return importmps;
-  }
-
-  if (!path.isAbsolute(file)) {
-    file = path.resolve(cwd, file);
-  }
-
-  const fullFilePath = normalizeFilepath(file);
-
-  if (!pathExistsSync(fullFilePath)) {
-    return importmps;
-  }
-
-  const content = fs.readFileSync(fullFilePath, {
-    encoding: "utf8",
-  });
-
-  try {
-    return parseFromString(content, `file://${cwd}/`);
-  } catch {
-    return importmps;
-  }
-}
 
 function parseModuleName(
   moduleName: string,

--- a/src/ts-utils.ts
+++ b/src/ts-utils.ts
@@ -1,0 +1,42 @@
+import ts, { SourceFile, Node } from "typescript/lib/tsserverlibrary";
+
+export function getTsUtils(languageService: ts.LanguageService): TsUtils {
+    function findNode(sourceFile: ts.SourceFile, position: number) {
+        function find(node: ts.Node): ts.Node | undefined {
+          if (position >= node.getStart() && position < node.getEnd()) {
+            return ts.forEachChild(node, find) || node;
+          }
+        }
+        
+        return find(sourceFile);
+    }
+
+    return {
+        getSourceFile (fileName: string) {
+            const program = languageService.getProgram();
+            if (!program) {
+                throw new Error('language service host does not have program!');
+            }
+            
+            const s = program.getSourceFile(fileName);
+            if (!s) {
+              throw new Error('No source file: ' + fileName);
+            }
+            return s;
+        },
+        getNode (fileName: string, position: number) {
+            return findNode(this.getSourceFile(fileName), position);
+        },
+        getNodeText(node: ts.Node, fileName: string) {
+            const sourceFile = this.getSourceFile(fileName);
+            const sourceText = sourceFile.text;
+            return sourceText.slice(node.pos, node.end);
+        },
+    }
+}
+
+export interface TsUtils {
+    getSourceFile(fileName: string): SourceFile;
+    getNode (fileName: string, position: number): Node | undefined;
+    getNodeText(node: ts.Node, fileName: string): string;
+}

--- a/src/ts-utils.ts
+++ b/src/ts-utils.ts
@@ -1,42 +1,42 @@
 import ts, { SourceFile, Node } from "typescript/lib/tsserverlibrary";
 
 export function getTsUtils(languageService: ts.LanguageService): TsUtils {
-    function findNode(sourceFile: ts.SourceFile, position: number) {
-        function find(node: ts.Node): ts.Node | undefined {
-          if (position >= node.getStart() && position < node.getEnd()) {
-            return ts.forEachChild(node, find) || node;
-          }
-        }
-        
-        return find(sourceFile);
+  function findNode(sourceFile: ts.SourceFile, position: number) {
+    function find(node: ts.Node): ts.Node | undefined {
+      if (position >= node.getStart() && position < node.getEnd()) {
+        return ts.forEachChild(node, find) || node;
+      }
     }
+    
+    return find(sourceFile);
+  }
 
-    return {
-        getSourceFile (fileName: string) {
-            const program = languageService.getProgram();
-            if (!program) {
-                throw new Error('language service host does not have program!');
-            }
-            
-            const s = program.getSourceFile(fileName);
-            if (!s) {
-              throw new Error('No source file: ' + fileName);
-            }
-            return s;
-        },
-        getNode (fileName: string, position: number) {
-            return findNode(this.getSourceFile(fileName), position);
-        },
-        getNodeText(node: ts.Node, fileName: string) {
-            const sourceFile = this.getSourceFile(fileName);
-            const sourceText = sourceFile.text;
-            return sourceText.slice(node.pos, node.end);
-        },
-    }
+  return {
+    getSourceFile (fileName: string) {
+      const program = languageService.getProgram();
+      if (!program) {
+        throw new Error('language service host does not have program!');
+      }
+      
+      const s = program.getSourceFile(fileName);
+      if (!s) {
+        throw new Error('No source file: ' + fileName);
+      }
+      return s;
+    },
+    getNode (fileName: string, position: number) {
+      return findNode(this.getSourceFile(fileName), position);
+    },
+    getNodeText(node: ts.Node, fileName: string) {
+      const sourceFile = this.getSourceFile(fileName);
+      const sourceText = sourceFile.text;
+      return sourceText.slice(node.pos, node.end);
+    },
+  }
 }
 
 export interface TsUtils {
-    getSourceFile(fileName: string): SourceFile;
-    getNode (fileName: string, position: number): Node | undefined;
-    getNodeText(node: ts.Node, fileName: string): string;
+  getSourceFile(fileName: string): SourceFile;
+  getNode (fileName: string, position: number): Node | undefined;
+  getNodeText(node: ts.Node, fileName: string): string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,10 @@ import * as fs from "fs";
 import * as path from "path";
 import crypto from "crypto";
 import { URL } from "url";
+import {
+  ImportMaps,
+  parseFromString,
+} from "import-maps";
 
 export function getDenoDir(): string {
   // ref https://deno.land/manual.html
@@ -148,5 +152,36 @@ export function pathExistsSync(filepath: string): boolean {
     return true;
   } catch (err) {
     return false;
+  }
+}
+
+export function parseImportMapFromFile(cwd: string, file?: string): ImportMaps {
+  const importmps: ImportMaps = {
+    imports: {},
+    scopes: {},
+  };
+
+  if (file == null) {
+    return importmps;
+  }
+
+  if (!path.isAbsolute(file)) {
+    file = path.resolve(cwd, file);
+  }
+
+  const fullFilePath = normalizeFilepath(file);
+
+  if (!pathExistsSync(fullFilePath)) {
+    return importmps;
+  }
+
+  const content = fs.readFileSync(fullFilePath, {
+    encoding: "utf8",
+  });
+
+  try {
+    return parseFromString(content, `file://${cwd}/`);
+  } catch {
+    return importmps;
   }
 }


### PR DESCRIPTION
Implements #48 
New feature to add autocompletes for imports.

generates autocomplete for the following cases:

- external imports starting with `https://`. Import paths are read from `$CACHE_DIR/deno/gen`

- relative imports starting with `./` or `../`

- imports matching entries in `importmap.json`