### PR TITLE
Add support for URLs with non-default ports

### DIFF
--- a/src/module_resolver/remote_module_resolver.ts
+++ b/src/module_resolver/remote_module_resolver.ts
@@ -17,7 +17,7 @@ export const remoteModuleResolver: IModuleResolver = {
     const originDir = path.join(
       getDenoDepsDir(),
       url.protocol.replace(/:$/, ""), // https: -> https
-      `${url.hostname}${url.port ? `_PORT${url.port}` : ''}`, // hostname.xyz:3000 -> hostname.xyz_PORT3000
+      `${url.hostname}${url.port ? `_PORT${url.port}` : ""}`, // hostname.xyz:3000 -> hostname.xyz_PORT3000
     );
 
     const hash = hashURL(url);

--- a/src/module_resolver/remote_module_resolver.ts
+++ b/src/module_resolver/remote_module_resolver.ts
@@ -17,7 +17,7 @@ export const remoteModuleResolver: IModuleResolver = {
     const originDir = path.join(
       getDenoDepsDir(),
       url.protocol.replace(/:$/, ""), // https: -> https
-      url.hostname,
+      `${url.hostname}${url.port ? `_PORT${url.port}` : ''}`, // hostname.xyz:3000 -> hostname.xyz_PORT3000
     );
 
     const hash = hashURL(url);


### PR DESCRIPTION
Ref. Deno source: https://github.com/denoland/deno/blob/2da084058397efd6f517ba98c9882760ec0a7bd6/cli/disk_cache.rs#L55

This adds support for port numbers in remote module resolution. I didn't see any places that would support a test for this, so please test with a local file server before merging.

I think this should resolve https://github.com/denoland/vscode_deno/issues/24#issuecomment-649918614.